### PR TITLE
Lpsolver bugfix

### DIFF
--- a/src/main/java/dk/alexandra/fresco/lib/helper/builder/NumericProtocolBuilder.java
+++ b/src/main/java/dk/alexandra/fresco/lib/helper/builder/NumericProtocolBuilder.java
@@ -32,6 +32,7 @@ import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
 import dk.alexandra.fresco.lib.helper.AbstractRepeatProtocol;
+import dk.alexandra.fresco.lib.helper.CopyProtocolImpl;
 import dk.alexandra.fresco.lib.helper.builder.tree.TreeCircuit;
 import dk.alexandra.fresco.lib.helper.builder.tree.TreeCircuitNodeGenerator;
 
@@ -193,8 +194,8 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 				out[i] = add(left[i], right[i]);
 			}
 		} catch (IndexOutOfBoundsException e) {
-			throw new IllegalArgumentException("The righthand input array "
-					+ "most be at least as long as the left hand input arry", e);
+			throw new IllegalArgumentException(
+					"The righthand input array " + "most be at least as long as the left hand input arry", e);
 		}
 		endCurScope();
 		return out;
@@ -214,8 +215,7 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 		@Override
 		protected ProtocolProducer getNextGateProducer() {
 			if (i < left.length) {
-				ProtocolProducer addition = bnp.getAddProtocol(left[i], right[i],
-						out[i]);
+				ProtocolProducer addition = bnp.getAddProtocol(left[i], right[i], out[i]);
 				i++;
 				return addition;
 			} else {
@@ -279,9 +279,10 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 			return terms.length;
 		}
 	}
-	
+
 	/**
 	 * Takes a number of values and multiplies them all.
+	 * 
 	 * @param terms
 	 * @return
 	 */
@@ -291,7 +292,7 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 		append(multTree);
 		return sum;
 	}
-	
+
 	private class MultNodeGenerator implements TreeCircuitNodeGenerator {
 
 		private SInt[] terms;
@@ -388,8 +389,8 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 				out[i] = mult(left[i], right[i]);
 			}
 		} catch (IndexOutOfBoundsException e) {
-			throw new IllegalArgumentException("The righthand input array "
-					+ "most be at least as long as the left hand input arry", e);
+			throw new IllegalArgumentException(
+					"The righthand input array " + "most be at least as long as the left hand input arry", e);
 		}
 		endCurScope();
 		return out;
@@ -430,11 +431,55 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 				append(bnp.getSubtractCircuit(left[i], right[i], out[i]));
 			}
 		} catch (IndexOutOfBoundsException e) {
-			throw new IllegalArgumentException("The righthand input array "
-					+ "most be at least as long as the left hand input arry", e);
+			throw new IllegalArgumentException(
+					"The righthand input array " + "most be at least as long as the left hand input arry", e);
 		}
 		endCurScope();
 		return out;
+	}
+
+	/**
+	 * Computes the conditional selection operation. I.e., concretely computes
+	 * the value <code>r</code> as
+	 * <code> selector*(left - right) + right </code> For
+	 * <code>selector == 0</code> this gives a value equal to <code>right</code>
+	 * , for <code>selector == 1</code> a value equal to <code>left</code>.
+	 * 
+	 * @param selector
+	 *            should be either 0 or 1.
+	 * @param left
+	 *            the left hand value
+	 * @param right
+	 *            the right hand value
+	 * @return a SInt holding the value of
+	 *         <code> selector*(left - right) + right </code>
+	 */
+	public SInt conditionalSelect(SInt selector, SInt left, SInt right) {
+		SInt r = getSInt();
+		conditionalSelect(selector, left, right, r);
+		return r;
+	}
+
+	/**
+	 * In place version of {@link #conditionalSelect(SInt, SInt, SInt)}
+	 * 
+	 * @param selector
+	 *            should be either 0 or 1.
+	 * @param left
+	 *            the left hand value
+	 * @param right
+	 *            the right hand value
+	 * @param result
+	 *            a SInt in which to put the result. I.e, the value of
+	 *            <code> selector*(left - right) + right </code>
+	 */
+	public void conditionalSelect(SInt selector, SInt left, SInt right, SInt result) {
+		beginSeqScope();
+		SInt diff = sub(left, right);
+		SInt prod = mult(diff, selector);
+		append(bnp.getAddProtocol(prod, right, result));
+		endCurScope();
+		return;
 	}
 
 	public SInt innerProduct(SInt[] left, SInt[] right) {
@@ -443,6 +488,20 @@ public class NumericProtocolBuilder extends AbstractProtocolBuilder {
 		SInt innerProduct = this.sum(directProduct);
 		endCurScope();
 		return innerProduct;
+	}
+
+	/**
+	 * Copies the value of one SInt into an other SInt.
+	 * 
+	 * Note: this uses the generic CopyProtocol implementation, it is not clear
+	 * if this is safe for all protocol suites.
+	 * @param to
+	 *            the SInt to copy to
+	 * @param from
+	 *            the SInt to copy from
+	 */
+	public void copy(SInt to, SInt from) {
+		append(new CopyProtocolImpl<SInt>(from, to));
 	}
 
 	@Override

--- a/src/main/java/dk/alexandra/fresco/lib/lp/LPFactory.java
+++ b/src/main/java/dk/alexandra/fresco/lib/lp/LPFactory.java
@@ -36,160 +36,269 @@ import dk.alexandra.fresco.lib.math.integer.inv.InversionProtocolFactory;
 import dk.alexandra.fresco.lib.math.integer.linalg.EntrywiseProductFactory;
 import dk.alexandra.fresco.lib.math.integer.linalg.InnerProductProtocol;
 import dk.alexandra.fresco.lib.math.integer.min.MinimumProtocol;
+import dk.alexandra.fresco.lib.math.integer.min.MinInfFracProtocol;
 import dk.alexandra.fresco.lib.math.integer.min.MinimumFractionProtocol;
 
-public interface LPFactory extends InversionProtocolFactory, MarkerFactory, CopyProtocolFactory<SInt>, EntrywiseProductFactory {
-	
+public interface LPFactory
+		extends InversionProtocolFactory, MarkerFactory, CopyProtocolFactory<SInt>, EntrywiseProductFactory {
+
 	/**
 	 * 
-	 * @param selector input
-	 * @param a input - choice 1 if selector is true (1)
-	 * @param b input - choice 2 if selector is false (0)
-	 * @param result output - either a or b.
+	 * @param selector
+	 *            input
+	 * @param a
+	 *            input - choice 1 if selector is true (1)
+	 * @param b
+	 *            input - choice 2 if selector is false (0)
+	 * @param result
+	 *            output - either a or b.
 	 * @return
 	 */
 	public ConditionalSelectCircuit getConditionalSelectCircuit(SInt selector, SInt a, SInt b, SInt result);
-	
-	
-	
+
 	/**
-	 * inputs are the as, m is the base recursion result, 
-	 * and cs are the outputs of the intermediate recursions.
-	 * @param as input
-	 * @param m output
-	 * @param cs outputs
+	 * inputs are the as, m is the base recursion result, and cs are the outputs
+	 * of the intermediate recursions.
+	 * 
+	 * @param as
+	 *            input
+	 * @param m
+	 *            output
+	 * @param cs
+	 *            outputs
 	 * @return
 	 */
 	public MinimumProtocol getMinimumCircuit(SInt[] as, SInt m, SInt[] cs);
-	
-	
+
 	/**
-	 * Finds the minimum in an list of fractions. Note fractions are given as separate arrays of numerators and denominators. 
-	 * @param ns input - the numerators
-	 * @param ds input - the denominators 
-	 * @param nm output - the numerator of the minimum fraction
-	 * @param dm output - the denominator of the minimum fraction
-	 * @param cs output - the index vector for indicating the minimum fraction
+	 * Finds the minimum in an list of fractions. Note fractions are given as
+	 * separate arrays of numerators and denominators.
+	 * 
+	 * @param ns
+	 *            input - the numerators
+	 * @param ds
+	 *            input - the denominators
+	 * @param nm
+	 *            output - the numerator of the minimum fraction
+	 * @param dm
+	 *            output - the denominator of the minimum fraction
+	 * @param cs
+	 *            output - the index vector for indicating the minimum fraction
 	 * @return
 	 */
 	public MinimumFractionProtocol getMinimumFractionCircuit(SInt[] ns, SInt[] ds, SInt nm, SInt dm, SInt[] cs);
-	
-	
-	
+
 	/**
 	 * 
-	 * @param x1 input
-	 * @param x2 input
-	 * @param result output - [1] (true) or [0] (false) (result of x1 <= x2)
-	 * @param longCompare - true indicates that we are comparing long numbers and should use twice the bit length
+	 * @param x1
+	 *            input
+	 * @param x2
+	 *            input
+	 * @param result
+	 *            output - [1] (true) or [0] (false) (result of x1 <= x2)
+	 * @param longCompare
+	 *            - true indicates that we are comparing long numbers and should
+	 *            use twice the bit length
 	 * @return
 	 */
 	public ComparisonProtocol getComparisonCircuit(SInt x1, SInt x2, SInt result, boolean longCompare);
-	
+
 	/**
-	 * Returns a circuit for equality 
-	 * @param bitlength the maximum bitlength of the two arguments
-	 * @param securityParam the security parameter
-	 * @param x1 input - a number
-	 * @param x2 input - a number
-	 * @param result output - [1] (true) or [0] (false) (result of x1 = x2)
+	 * Returns a circuit for equality
+	 * 
+	 * @param bitlength
+	 *            the maximum bitlength of the two arguments
+	 * @param securityParam
+	 *            the security parameter
+	 * @param x1
+	 *            input - a number
+	 * @param x2
+	 *            input - a number
+	 * @param result
+	 *            output - [1] (true) or [0] (false) (result of x1 = x2)
 	 * 
 	 * @return a circuit for equality
 	 */
 	public EqualityProtocol getEqualityCircuit(int bitLength, int securityParam, SInt x, SInt y, SInt result);
-	
-	
-	/**
-	 * Computes the index of the entering variable.
-	 * @param tableau input - a tableau of dimension (m + 1) x (n + m + 1) i.e. the C matrix is of dimension m x (n+m)
-	 * @param updateMatrix input - an updateMatrix of dimension (m + 1) x (m + 1)
-	 * @param enteringIndex output - an index vector indexing the minimum entry in the updated F vector, corresponding the entering variable
-	 * @param minimum output - the minimum entry in the F vector
-	 * @return
-	 */
-	public EnteringVariableCircuit getEnteringVariableCircuit(LPTableau tableau, Matrix<SInt> updateMatrix, SInt[] enteringIndex, SInt minimum);
 
 	/**
-	 * Computes the index of the exiting variable along with values needed to compute the update matrix for this iteration
-	 * @param tableau input - a tableau of dimension (m + 1) x (n + m + 1) i.e. the C matrix is of dimension m x (n+m)
-	 * @param updateMatrix input - an updateMatrix of dimension (m + 1) x (m + 1)
-	 * @param enteringIndex input - an index vector indexing the variable to leave the basis
-	 * @param exitingIndex output - an index vector indexing the most constraining constraint, corresponding to the exiting variable
-	 * @param updateColumn output - the column used to generate the update matrix of this iteration 
-	 * @param pivot output - the pivot element used to generate the update matrix of this iteration 
-	 * @return 
-	 */
-	public ExitingVariableCircuit getExitingVariableCircuit(LPTableau tableau, Matrix<SInt> updateMatrix, SInt[] enteringIndex, SInt[] exitingIndex, SInt[] updateColumn, SInt pivot);
-	
-	/**
-	 * @param oldUpdateMatrix input - the current update matrix
-	 * @param L input - the index vector of the exiting variable
-	 * @param C input - the column to be inserted into the update matrix of this iteration
-	 * @param p input - the pivot element
-	 * @param p_prime input - the previous pivot element
-	 * @param newUpdateMatrix output - the new update matrix
+	 * Computes the index of the entering variable.
+	 * 
+	 * @param tableau
+	 *            input - a tableau of dimension (m + 1) x (n + m + 1) i.e. the
+	 *            C matrix is of dimension m x (n+m)
+	 * @param updateMatrix
+	 *            input - an updateMatrix of dimension (m + 1) x (m + 1)
+	 * @param enteringIndex
+	 *            output - an index vector indexing the minimum entry in the
+	 *            updated F vector, corresponding the entering variable
+	 * @param minimum
+	 *            output - the minimum entry in the F vector
 	 * @return
 	 */
-	public UpdateMatrixCircuit getUpdateMatrixCircuit(Matrix<SInt> oldUpdateMatrix, SInt[] L, SInt[] C, SInt p, SInt p_prime, Matrix<SInt> newUpdateMatrix);
-	
+	public EnteringVariableCircuit getEnteringVariableCircuit(LPTableau tableau, Matrix<SInt> updateMatrix,
+			SInt[] enteringIndex, SInt minimum);
+
 	/**
-	 * @param aVector input - an n-dimensional vector
-	 * @param bVector input - an n-dimensional vector
-	 * @param result output - the inner product of the two input input vectors
+	 * Computes the index of the exiting variable along with values needed to
+	 * compute the update matrix for this iteration
+	 * 
+	 * @param tableau
+	 *            input - a tableau of dimension (m + 1) x (n + m + 1) i.e. the
+	 *            C matrix is of dimension m x (n+m)
+	 * @param updateMatrix
+	 *            input - an updateMatrix of dimension (m + 1) x (m + 1)
+	 * @param enteringIndex
+	 *            input - an index vector indexing the variable to leave the
+	 *            basis
+	 * @param exitingIndex
+	 *            output - an index vector indexing the most constraining
+	 *            constraint, corresponding to the exiting variable
+	 * @param updateColumn
+	 *            output - the column used to generate the update matrix of this
+	 *            iteration
+	 * @param pivot
+	 *            output - the pivot element used to generate the update matrix
+	 *            of this iteration
+	 * @return
+	 */
+	public ExitingVariableCircuit getExitingVariableCircuit(LPTableau tableau, Matrix<SInt> updateMatrix,
+			SInt[] enteringIndex, SInt[] exitingIndex, SInt[] updateColumn, SInt pivot);
+
+	/**
+	 * @param oldUpdateMatrix
+	 *            input - the current update matrix
+	 * @param L
+	 *            input - the index vector of the exiting variable
+	 * @param C
+	 *            input - the column to be inserted into the update matrix of
+	 *            this iteration
+	 * @param p
+	 *            input - the pivot element
+	 * @param p_prime
+	 *            input - the previous pivot element
+	 * @param newUpdateMatrix
+	 *            output - the new update matrix
+	 * @return
+	 */
+	public UpdateMatrixCircuit getUpdateMatrixCircuit(Matrix<SInt> oldUpdateMatrix, SInt[] L, SInt[] C, SInt p,
+			SInt p_prime, Matrix<SInt> newUpdateMatrix);
+
+	/**
+	 * @param aVector
+	 *            input - an n-dimensional vector
+	 * @param bVector
+	 *            input - an n-dimensional vector
+	 * @param result
+	 *            output - the inner product of the two input input vectors
 	 * @return a circuit computing the inner product of two vectors
 	 */
 	public InnerProductProtocol getInnerProductCircuit(SInt[] aVector, SInt[] bVector, SInt result);
-	
+
 	/**
 	 * Computes the optimal value after the last simplex iteration
-	 * @param updateMatrix input - the current update matrix
-	 * @param B input - the B vector of the tableau
-	 * @param pivot input - the previous pivot element
-	 * @param optimalValue output - optimal value
+	 * 
+	 * @param updateMatrix
+	 *            input - the current update matrix
+	 * @param B
+	 *            input - the B vector of the tableau
+	 * @param pivot
+	 *            input - the previous pivot element
+	 * @param optimalValue
+	 *            output - optimal value
 	 * @return
 	 */
-	public OptimalValueCircuit getOptimalValueCircuit(Matrix<SInt> updateMatrix, SInt[] B, SInt pivot, SInt optimalValue);
-	
+	public OptimalValueCircuit getOptimalValueCircuit(Matrix<SInt> updateMatrix, SInt[] B, SInt pivot,
+			SInt optimalValue);
+
 	/**
-	 * Computes the numerator of the optimal value after the last simplex iteration (the pivot element being the denominator)
-	 * @param updateMatrix input - the current update matrix
-	 * @param B input - the B vector of the tableau
-	 * @param optimalNumerator output - optimal numerator
+	 * Computes the numerator of the optimal value after the last simplex
+	 * iteration (the pivot element being the denominator)
+	 * 
+	 * @param updateMatrix
+	 *            input - the current update matrix
+	 * @param B
+	 *            input - the B vector of the tableau
+	 * @param optimalNumerator
+	 *            output - optimal numerator
 	 * @return
 	 */
-	public OptimalNumeratorCircuit getOptimalNumeratorCircuit(Matrix<SInt> updateMatrix, SInt[] B, SInt optimalNumerator);
-	
+	public OptimalNumeratorCircuit getOptimalNumeratorCircuit(Matrix<SInt> updateMatrix, SInt[] B,
+			SInt optimalNumerator);
+
 	/**
-	 * Ranks a rational value against a list of rational values. I.e. for a value x/y finds the number of  
-	 * of values u/v in a list so that u/v <= x/y.
-	 * @param numerators input - a list of numerators
-	 * @param denominators input - a list of denominators
-	 * @param numerator input - the numerator of the rational to rank
-	 * @param denominator input - the denominator of the rational to rank
-	 * @param rank output - the rank
+	 * Ranks a rational value against a list of rational values. I.e. for a
+	 * value x/y finds the number of of values u/v in a list so that u/v <= x/y.
+	 * 
+	 * @param numerators
+	 *            input - a list of numerators
+	 * @param denominators
+	 *            input - a list of denominators
+	 * @param numerator
+	 *            input - the numerator of the rational to rank
+	 * @param denominator
+	 *            input - the denominator of the rational to rank
+	 * @param rank
+	 *            output - the rank
 	 * @return
 	 */
-	public RankCircuit getRankCircuit(SInt[] numerators, SInt[] denominators, SInt numerator, SInt denominator, SInt rank);
-	
+	public RankCircuit getRankCircuit(SInt[] numerators, SInt[] denominators, SInt numerator, SInt denominator,
+			SInt rank);
+
 	/**
-	 * Ranks a value against a list of values. I.e. for a value x finds the number of  
-	 * of values u in a list so that u <= x.
-	 * @param values input - a list of values
-	 * @param rankValue input - a value to rank against the list
-	 * @param rank output - will contain the rank of the value to be ranked
+	 * Ranks a value against a list of values. I.e. for a value x finds the
+	 * number of of values u in a list so that u <= x.
+	 * 
+	 * @param values
+	 *            input - a list of values
+	 * @param rankValue
+	 *            input - a value to rank against the list
+	 * @param rank
+	 *            output - will contain the rank of the value to be ranked
 	 * @return
 	 */
 	public RankCircuit getRankCircuit(SInt[] values, SInt rankValue, SInt rank);
-	
+
 	/**
-	 * Returns a circuit solving an LP-problem from an initial tableau, update matrix and value for the previous pivot. 
-	 * (Usually the update matrix and pivot will be initialized to the identity matrix and the value one respectively). 
-	 * The update matrix and pivot will be update through the computation, and used to compute the optimal value of the 
-	 * LP-problem after the circuit has been evaluated.
+	 * Returns a circuit solving an LP-problem from an initial tableau, update
+	 * matrix and value for the previous pivot. (Usually the update matrix and
+	 * pivot will be initialized to the identity matrix and the value one
+	 * respectively). The update matrix and pivot will be update through the
+	 * computation, and used to compute the optimal value of the LP-problem
+	 * after the circuit has been evaluated.
+	 * 
 	 * @param tableau
 	 * @param updateMatrix
 	 * @param pivot
 	 * @return an LPSolverCircuit
 	 */
-	public LPSolverCircuit getLPSolverCircuit(LPTableau tableau, Matrix<SInt> updateMatrix, SInt pivot);	
+	public LPSolverCircuit getLPSolverCircuit(LPTableau tableau, Matrix<SInt> updateMatrix, SInt pivot);
+
+	/**
+	 * Finds the minimum in an list of fractions. Note fractions are given as
+	 * separate arrays of numerators and denominators. Also allows to indicate
+	 * certain fractions that should take a value of infinity in comparisons.
+	 * I.e., indicate fractions that should never be chosen as the minimum.
+	 * 
+	 * @param ns
+	 *            input - the numerators
+	 * @param ds
+	 *            input - the denominators
+	 * @param infs
+	 *            input - should hold 0/1 values. If the i'th value is 1 the
+	 *            i'th fraction should be regarded as having an infinity value
+	 *            in the comparisons
+	 * @param nm
+	 *            output - the numerator of the minimum fraction
+	 * @param dm
+	 *            output - the denominator of the minimum fraction
+	 * @param infm
+	 *            output - the infinity indicator of the minimum fraction. I.e.,
+	 *            should only be 1 if all fractions are regarded as infinity and
+	 *            0 otherwise.
+	 * @param cs
+	 *            output - the index vector for indicating the minimum fraction
+	 * @return
+	 */
+	MinInfFracProtocol getMinInfFracProtocol(SInt[] ns, SInt[] ds, SInt[] infs, SInt nm, SInt dm, SInt infm, SInt[] cs);
 }

--- a/src/main/java/dk/alexandra/fresco/lib/lp/LPFactoryImpl.java
+++ b/src/main/java/dk/alexandra/fresco/lib/lp/LPFactoryImpl.java
@@ -29,6 +29,8 @@ package dk.alexandra.fresco.lib.lp;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocol;
+import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactory;
+import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactoryImpl;
 import dk.alexandra.fresco.lib.compare.ConditionalSelectCircuit;
 import dk.alexandra.fresco.lib.compare.ConditionalSelectCircuitImpl;
 import dk.alexandra.fresco.lib.compare.MiscOIntGenerators;
@@ -59,6 +61,7 @@ import dk.alexandra.fresco.lib.math.integer.linalg.InnerProductFactoryImpl;
 import dk.alexandra.fresco.lib.math.integer.linalg.InnerProductProtocol;
 import dk.alexandra.fresco.lib.math.integer.min.MinimumProtocol;
 import dk.alexandra.fresco.lib.math.integer.min.MinimumProtocolImpl;
+import dk.alexandra.fresco.lib.math.integer.min.MinInfFracProtocol;
 import dk.alexandra.fresco.lib.math.integer.min.MinimumFractionProtocol;
 import dk.alexandra.fresco.lib.math.integer.min.MinimumFractionProtocolImpl;
 
@@ -72,6 +75,7 @@ public class LPFactoryImpl implements LPFactory {
 	private final InnerProductFactory innerProductFactory;
 	private final ZeroTestProtocolFactory zeroTestProtocolFactory;
 	private final MiscOIntGenerators misc;
+	private ComparisonProtocolFactory compFactory;
 
 	public LPFactoryImpl(int securityParameter, BasicNumericFactory bnf,
 			LocalInversionFactory localInvFactory,
@@ -88,6 +92,7 @@ public class LPFactoryImpl implements LPFactory {
 		misc = new MiscOIntGenerators(bnf);
 		this.zeroTestProtocolFactory = new ZeroTestProtocolFactoryImpl(bnf,
 				expFromOIntFactory, numericBitFactory, numericNegateBitFactory, expFactory);
+		this.compFactory = new ComparisonProtocolFactoryImpl(securityParameter, bnf, localInvFactory, numericBitFactory, expFromOIntFactory, expFactory);
 	}
 
 	@Override
@@ -132,6 +137,12 @@ public class LPFactoryImpl implements LPFactory {
 	public MinimumFractionProtocol getMinimumFractionCircuit(SInt[] ns,
 			SInt[] ds, SInt nm, SInt dm, SInt[] cs) {
 		return new MinimumFractionProtocolImpl(ns, ds, nm, dm, cs, bnf, this);
+	}
+	
+	@Override
+	public MinInfFracProtocol getMinInfFracProtocol(SInt[] ns,
+			SInt[] ds, SInt[] infs, SInt nm, SInt dm, SInt infm, SInt[] cs) {
+		return new MinInfFracProtocol(ns, ds, infs, nm, dm, infm, cs, bnf, compFactory);
 	}
 
 	@Override

--- a/src/main/java/dk/alexandra/fresco/lib/lp/LPSolverCircuit.java
+++ b/src/main/java/dk/alexandra/fresco/lib/lp/LPSolverCircuit.java
@@ -27,7 +27,6 @@
 package dk.alexandra.fresco.lib.lp;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 
 import dk.alexandra.fresco.framework.MPCException;
 import dk.alexandra.fresco.framework.NativeProtocol;
@@ -41,7 +40,6 @@ import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
 import dk.alexandra.fresco.lib.helper.AbstractRoundBasedProtocol;
 import dk.alexandra.fresco.lib.helper.CopyProtocol;
 import dk.alexandra.fresco.lib.helper.ParallelProtocolProducer;
-import dk.alexandra.fresco.lib.helper.builder.NumericIOBuilder;
 import dk.alexandra.fresco.lib.helper.sequential.SequentialProtocolProducer;
 
 public class LPSolverCircuit implements Protocol {
@@ -64,7 +62,7 @@ public class LPSolverCircuit implements Protocol {
 	private SInt pivot;
 	private SInt[] enteringIndex;
 	public static int iterations = 0;
-
+	
 	public LPSolverCircuit(LPTableau tableau, Matrix<SInt> updateMatrix,
 			SInt pivot, LPFactory lpProvider, BasicNumericFactory bnProvider) {
 		if (checkDimensions(tableau, updateMatrix)) {
@@ -100,7 +98,6 @@ public class LPSolverCircuit implements Protocol {
 			} else if (state == STATE.PHASE2) {
 				boolean terminated = terminationOut.getValue().equals(
 						BigInteger.ONE);
-				System.out.println("Are we about to terminate? :  " + terminated);
 				if (!terminated) {					
 					gp = phaseTwoCircuit();					
 				} else {
@@ -216,12 +213,12 @@ public class LPSolverCircuit implements Protocol {
 				positive, true);
 		ProtocolProducer output = bnProvider.getOpenProtocol(positive,
 				terminationOut);
-
 		ProtocolProducer phaseOne = new SequentialProtocolProducer(enteringProducer,
 				comp, output);
 		return phaseOne;
 	}
 		
+	@SuppressWarnings("unused")
 	private ProtocolProducer blandPhaseOneCircuit() {
 		int noVariables = tableau.getC().getWidth();
 		terminationOut = bnProvider.getOInt();

--- a/src/main/java/dk/alexandra/fresco/lib/math/integer/min/MinInfFracProtocol.java
+++ b/src/main/java/dk/alexandra/fresco/lib/math/integer/min/MinInfFracProtocol.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.lib.math.integer.min;
+
+import dk.alexandra.fresco.framework.MPCException;
+import dk.alexandra.fresco.framework.ProtocolProducer;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.compare.ComparisonProtocol;
+import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactory;
+import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
+import dk.alexandra.fresco.lib.helper.AbstractRoundBasedProtocol;
+import dk.alexandra.fresco.lib.helper.builder.NumericProtocolBuilder;
+
+/**
+ * Implements a version of the <code>MinimumFractionProtocol</code> that allows
+ * to indicate that certain fractions should be regarded as having infinite
+ * value. I.e., to indicate that those fractions should never be chosen as the
+ * minimum. We do this by taking for each fraction a infinity indicator bit
+ * which can than be used to adjust any comparison result for the indicated
+ * fractions. This solves a problem in the Simplex solver where we need to find
+ * the minimum fraction larger than 0, in a list of fractions.
+ * 
+ * This improves on a previous solution that simply tried to set all fractions
+ * smaller than or equal to 0 to a very large value (essentially assuming this
+ * value would be a good approximation of infinity). Such a solution however,
+ * turns out to be prone to overflow problems, and picking the very larger
+ * value, is also non-trivial.
+ * 
+ *
+ */
+public class MinInfFracProtocol extends AbstractRoundBasedProtocol implements MinimumFractionProtocol {
+
+	private SInt[] cs;
+	private ComparisonProtocolFactory cFac;
+	private BasicNumericFactory nFac;
+	private int layer = 0;
+	private Frac[] fs;
+	private Frac fm;
+	private SInt one;
+	private State state;
+	private SInt[] tmpCs;
+
+	private enum State {
+		FIND_MIN, UPDATE_CS
+	};
+
+	/**
+	 * Constructs a protocol finding the minimum of a list of fractions. For
+	 * each fraction a 0/1 value should be given to indicate whether or not that
+	 * fraction should be disregarded when finding the minimum (similar to
+	 * setting that fraction to a value of infinity).
+	 * 
+	 * @param ns
+	 *            input - a list of numerators
+	 * @param ds
+	 *            input - a list of denominators
+	 * @param infs
+	 *            input - a list of infinity indicators (should be a 0/1 value,
+	 *            1 indicating infinity)
+	 * @param nm
+	 *            output - the numerator of the minimum fraction
+	 * @param dm
+	 *            output - the denominator of the minimum fraction
+	 * @param infm
+	 *            output - the infinity indicator of the minimum fraction (i.e.,
+	 *            should only be one if all fractions are set to infinity)
+	 * @param cs
+	 *            output - an index into the input arrays indicating the
+	 *            position of the minimum fraction. I.e., <code>c[i] == 1</code>
+	 *            if the i'th fraction was the minimum and
+	 *            <code>c[i] == 0</code> otherwise.
+	 * @param nFac
+	 *            a basic numeric factory to be used.
+	 * @param cFac
+	 *            a comparison factory to be used.
+	 */
+	public MinInfFracProtocol(SInt[] ns, SInt[] ds, SInt[] infs, SInt nm, SInt dm, SInt infm, SInt[] cs,
+			BasicNumericFactory nFac, ComparisonProtocolFactory cFac) {
+		if (ns.length == ds.length && ns.length == cs.length) {
+			this.fs = new Frac[ns.length];
+			for (int i = 0; i < ns.length; i++) {
+				fs[i] = new Frac(ns[i], ds[i], infs[i]);
+			}
+			this.fm = new Frac(nm, dm, infm);
+			this.cs = cs;
+			this.nFac = nFac;
+			this.cFac = cFac;
+			this.state = State.FIND_MIN;
+		} else {
+			throw new MPCException("Sizes of input arrays does not match");
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see dk.alexandra.fresco.lib.helper.AbstractRoundBasedProtocol#nextGateProducer()
+	 */
+	@Override
+	public ProtocolProducer nextGateProducer() {
+		NumericProtocolBuilder npb = new NumericProtocolBuilder(nFac);
+		if (state == State.FIND_MIN) {
+			if (layer == 0) {
+				one = npb.known(1);
+				if (fs.length == 1) { // The trivial case
+					npb.copy(fm.n, fs[0].n);
+					npb.copy(fm.d, fs[0].d);
+					npb.copy(fm.inf, fs[0].inf);
+					npb.copy(cs[0], one);
+					return npb.getCircuit();
+				}
+			} else if (fs.length == 1) {
+				return null;
+			}
+			Frac[] tmpFs = new Frac[fs.length / 2 + (fs.length % 2)];
+			tmpFs[0] = new Frac(fm.n, fm.d, fm.inf);
+			for (int i = 1; i < tmpFs.length; i++) {
+				tmpFs[i] = new Frac(npb.getSInt(), npb.getSInt(), npb.getSInt());
+			}
+			tmpCs = npb.getSIntArray(fs.length / 2);
+			npb.beginParScope();
+			for (int i = 0; i < tmpCs.length; i++) {
+				npb.addGateProducer(minFraction(fs[i * 2], fs[i * 2 + 1], tmpCs[i], tmpFs[i]));
+			}
+			npb.endCurScope();
+			if (fs.length % 2 == 1) {
+				tmpFs[tmpFs.length - 1] = fs[fs.length - 1];
+			}
+			fs = tmpFs;
+			state = State.UPDATE_CS;
+		} else if (state == State.UPDATE_CS) {
+			int offset = 1 << (layer + 1);
+			if (layer == 0) {
+				npb.beginParScope();
+				for (int i = 0; i < tmpCs.length; i++) {
+					npb.beginSeqScope();
+					SInt c = tmpCs[i];
+					SInt notC = npb.sub(one, c);
+					npb.copy(cs[i * 2], c);					
+					npb.copy(cs[i*2+1], notC);
+					npb.endCurScope();
+				}
+				if (cs.length % 2 == 1) {
+					npb.copy(cs[cs.length - 1], one);
+				}
+				npb.endCurScope();
+			} else {
+				npb.beginParScope(); // CHANGE TO PAR!
+				for (int i = 0; i < tmpCs.length; i++) {
+					SInt c = tmpCs[i];
+					for (int j = i * offset; j < i * offset + offset / 2; j++) {
+						npb.beginSeqScope();
+						SInt tmp = npb.mult(c, cs[j]);
+						npb.copy(cs[j], tmp);
+						npb.endCurScope();
+					}
+					npb.beginSeqScope();
+					SInt notC = npb.sub(one, c);
+					npb.beginParScope();
+					int limit = (i + 1) * offset > cs.length ? cs.length : (i + 1) * offset;
+					for (int j = i * offset + offset / 2; j < limit; j++) {
+						npb.beginSeqScope();
+						SInt tmp = npb.mult(notC, cs[j]);
+						npb.copy(cs[j], tmp);
+						npb.endCurScope();
+					}
+					npb.endCurScope();
+					npb.endCurScope();
+				}
+				npb.endCurScope();
+			}
+			layer++;
+			state = State.FIND_MIN;
+		}
+		return npb.getCircuit();
+	}
+
+	private ProtocolProducer minFraction(Frac f0, Frac f1, SInt c, Frac r) {
+		NumericProtocolBuilder npb = new NumericProtocolBuilder(nFac);
+		npb.beginParScope();
+		SInt p1 = npb.mult(f0.n, f1.d);
+		SInt p2 = npb.mult(f1.n, f0.d);
+		npb.endCurScope();
+		npb.beginSeqScope();
+		SInt tmpC = npb.getSInt();
+		ComparisonProtocol comp = cFac.getGreaterThanProtocol(p1, p2, tmpC, true);
+		npb.addGateProducer(comp);
+		SInt notInf0 = npb.sub(one, f0.inf);
+		tmpC = npb.mult(notInf0, tmpC);
+		tmpC = npb.conditionalSelect(f1.inf, f1.inf, tmpC);
+		npb.copy(c, tmpC);
+		npb.beginParScope();
+		SInt rn = npb.conditionalSelect(c, f0.n, f1.n);
+		SInt rd = npb.conditionalSelect(c, f0.d, f1.d);
+		SInt rinf = npb.mult(f0.inf, f1.inf);
+		npb.endCurScope();
+		npb.beginParScope();
+		npb.copy(r.n, rn);
+		npb.copy(r.d, rd);
+		npb.copy(r.inf, rinf);
+		npb.endCurScope();
+		npb.endCurScope();
+		return npb.getCircuit();
+	}
+
+	/**
+	 * Helper class to represent a fraction consisting of a numerator denominator 
+	 * and an infinity indicator.
+	 */
+	private class Frac {
+		public SInt n, d, inf;
+
+		public Frac(SInt n, SInt d, SInt inf) {
+			super();
+			this.n = n;
+			this.d = d;
+			this.inf = inf;
+		}
+	}
+}

--- a/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic2Parties.java
+++ b/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic2Parties.java
@@ -211,6 +211,34 @@ public class TestSpdzBasicArithmetic2Parties {
 				EvaluationStrategy.SEQUENTIAL_BATCHED,
 				StorageStrategy.IN_MEMORY);
 	}
+	
+	@Test
+	public void test_MinInfFrac_Sequential() throws Exception {
+		runTest(new BasicArithmeticTests.TestMinInfFrac(),
+				EvaluationStrategy.SEQUENTIAL,
+				StorageStrategy.IN_MEMORY);
+	}
+	
+	@Test
+	public void test_MinInfFrac_SequentialBatched() throws Exception {
+		runTest(new BasicArithmeticTests.TestMinInfFrac(),
+				EvaluationStrategy.SEQUENTIAL_BATCHED,
+				StorageStrategy.IN_MEMORY);
+	}
+	
+	@Test
+	public void test_MinInfFrac_Parallel() throws Exception {
+		runTest(new BasicArithmeticTests.TestMinInfFrac(),
+				EvaluationStrategy.PARALLEL,
+				StorageStrategy.IN_MEMORY);
+	}
+	
+	@Test
+	public void test_MinInfFrac_ParallelBatched() throws Exception {
+		runTest(new BasicArithmeticTests.TestMinInfFrac(),
+				EvaluationStrategy.PARALLEL_BATCHED,
+				StorageStrategy.IN_MEMORY);
+	}
 
 	// TODO: Test with different security parameters.
 

--- a/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic3Parties.java
+++ b/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic3Parties.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import dk.alexandra.fresco.framework.ProtocolEvaluator;
@@ -205,7 +204,6 @@ public class TestSpdzBasicArithmetic3Parties {
 	}
 	
 	@Test
-	//@Ignore
 	public void test_Lots_Of_Mults_Sequential_Batched() throws Exception {
 		runTest(new BasicArithmeticTests.TestLotsMult(),
 				EvaluationStrategy.SEQUENTIAL_BATCHED,

--- a/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzLPBuildingBlocks.java
+++ b/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzLPBuildingBlocks.java
@@ -83,7 +83,7 @@ public class TestSpdzLPBuildingBlocks {
 				
 				@Override
 				public boolean useDummyData() {
-					return false;
+					return true;
 				}
 				
 				@Override


### PR DESCRIPTION
This fixes an error that made the LP-Solver fail when used on sufficiently larger values. The cause of the turned out to be an unfortunate implementation that gave overflow in the method we used to find the minimum positive fraction in the exiting variable protocol.

Also so addresses #12 by fixing the batched evaluation strategy so that sent messages are immediately received.