### PR TITLE
Fixes a crash bug caused by an incorrect cast.

### DIFF
--- a/src/main/java/dk/alexandra/fresco/framework/network/ScapiNetworkImpl.java
+++ b/src/main/java/dk/alexandra/fresco/framework/network/ScapiNetworkImpl.java
@@ -154,7 +154,7 @@ public class ScapiNetworkImpl implements Network {
 					PartyData pd = idToPartyData.get(partyId);
 					Map<String, Channel> channels = connections.get(pd);
 					String cStr = "" + i;
-					PlainChannel c = (PlainChannel)channels.get(cStr);
+					Channel c = channels.get(cStr);
 					Channel secureChannel;
 					String sharedSecretKey = sharedSecretKeys.get(id); 
 					try {
@@ -185,7 +185,7 @@ public class ScapiNetworkImpl implements Network {
 		return authedChannel;
 	}
 
-	private EncryptedChannel getSecureChannel(PlainChannel ch, String base64EncodedSSKey) throws InvalidKeyException, SecurityLevelException {
+	private EncryptedChannel getSecureChannel(Channel c, String base64EncodedSSKey) throws InvalidKeyException, SecurityLevelException {
 		byte[] aesFixedKey = Base64.decodeFromString(base64EncodedSSKey);
 		SecretKey aesKey = new SecretKeySpec(aesFixedKey, "AES");
 		AES encryptAes = new BcAES();
@@ -195,7 +195,7 @@ public class ScapiNetworkImpl implements Network {
 		macAes.setKey(aesKey);
 		ScCbcMacPrepending cbcMac = new ScCbcMacPrepending(macAes);
 		ScEncryptThenMac encThenMac = new ScEncryptThenMac(enc, cbcMac);
-		EncryptedChannel secureChannel = new EncryptedChannel(ch, encThenMac);
+		EncryptedChannel secureChannel = new EncryptedChannel(c, encThenMac);
 		return secureChannel;
 	}
 	


### PR DESCRIPTION
While experimenting with different network configurations, I've had this file cause exceptions on line 157 when it tries to cast a PlainTCPSocketChannel to a PlainChannel (which I expected would be a superclass of it, but apparently not). This commit applies the fix I found after some experimentation.

I'm not really familiar with SCAPI, so please don't merge this until somebody can reassure me that this is in fact the correct way to deal with this problem and won't, say, cause any security issues down the line.
