### PR TITLE
Fix commandline utility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,9 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.18.1</version>
             <configuration>
-                <excludedGroups>dk.alexandra.fresco.IntegrationTest</excludedGroups>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <excludedGroups>dk.alexandra.fresco.IntegrationTest</excludedGroups>
             </configuration>
         </plugin>
 

--- a/src/main/java/dk/alexandra/fresco/demo/DistanceDemo.java
+++ b/src/main/java/dk/alexandra/fresco/demo/DistanceDemo.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.demo;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
+
+import dk.alexandra.fresco.framework.Application;
+import dk.alexandra.fresco.framework.ProtocolFactory;
+import dk.alexandra.fresco.framework.ProtocolProducer;
+import dk.alexandra.fresco.framework.configuration.CmdLineUtil;
+import dk.alexandra.fresco.framework.sce.SCE;
+import dk.alexandra.fresco.framework.sce.SCEFactory;
+import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
+import dk.alexandra.fresco.framework.value.OInt;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
+import dk.alexandra.fresco.lib.helper.builder.NumericIOBuilder;
+import dk.alexandra.fresco.lib.helper.builder.NumericProtocolBuilder;
+
+/**
+ * A simple demo the distance between two secret points
+ */
+public class DistanceDemo implements Application {
+	
+	private static final long serialVersionUID = 6415583508947017554L;
+	
+	private int myId, myX, myY;
+	private SInt x1, y1, x2, y2;
+	public OInt distance;
+	
+	public DistanceDemo(int id, int x, int y) {
+		this.myId = id;
+		this.myX = x;
+		this.myY = y;
+	}
+
+	@Override
+	public ProtocolProducer prepareApplication(ProtocolFactory factory) {
+		BasicNumericFactory bnFac = (BasicNumericFactory)factory;
+		NumericProtocolBuilder npb = new NumericProtocolBuilder(bnFac);
+		NumericIOBuilder iob = new NumericIOBuilder(bnFac);
+		// Input points
+		iob.beginParScope();
+			x1 = (myId == 1) ? iob.input(myX, 1) : iob.input(1); 
+			y1 = (myId == 1) ? iob.input(myY, 1) : iob.input(1); 
+			x2 = (myId == 2) ? iob.input(myX, 2) : iob.input(2); 
+			y2 = (myId == 2) ? iob.input(myY, 2) : iob.input(2); 
+		iob.endCurScope();
+		// Compute distance
+		npb.beginParScope();
+			npb.beginSeqScope();
+				SInt dX = npb.sub(x1, x2);
+				SInt sqDX = npb.mult(dX, dX);
+			npb.endCurScope();
+			npb.beginSeqScope();
+				SInt dY = npb.sub(y1, y2);
+				SInt sqDY = npb.mult(dY, dY);
+			npb.endCurScope();
+		npb.endCurScope();
+		SInt result = npb.add(sqDX, sqDY);
+		iob.addProtocolProducer(npb.getProtocol());
+		// Output result
+		distance = iob.output(result);
+		return iob.getProtocol();
+	}
+	
+	public static void main(String[] args) {
+		CmdLineUtil cmdUtil = new CmdLineUtil();
+		SCEConfiguration sceConf = null;
+		int x, y;
+		x = y = 0;
+		try {	
+			cmdUtil.addOption(Option.builder("x")
+					.desc("The integer x coordinate of this party. "
+							+ "Note only party 1 and 2 should supply this input.")
+					.hasArg()
+					.build());	
+			cmdUtil.addOption(Option.builder("y")
+					.desc("The integer y coordinate of this party. "
+							+ "Note only party 1 and 2 should supply this input")
+					.hasArg()
+					.build());
+			CommandLine cmd = cmdUtil.parse(args);
+			sceConf = cmdUtil.getSCEConfiguration();
+			
+			if (sceConf.getMyId() == 1 || sceConf.getMyId() == 2) {
+				if (!cmd.hasOption("x") || !cmd.hasOption("y")) {
+					throw new ParseException("Party 1 and 2 must submit input");
+				} else {
+					x = Integer.parseInt(cmd.getOptionValue("x"));
+					y = Integer.parseInt(cmd.getOptionValue("y"));
+				}
+			} else {
+				if (cmd.hasOption("x") || cmd.hasOption("y")) 
+					throw new ParseException("Only party 1 and 2 should submit input");
+			}
+			
+		} catch (ParseException | IllegalArgumentException e) {
+			System.out.println("Error: " + e);
+			System.out.println();
+			cmdUtil.displayHelp();
+			System.exit(-1);	
+		} 
+		DistanceDemo distDemo = new DistanceDemo(sceConf.getMyId(), x, y);
+		SCE sce = SCEFactory.getSCEFromConfiguration(sceConf);
+		try {
+			sce.runApplication(distDemo);
+		} catch (Exception e) {
+			System.out.println("Error while doing MPC: " + e.getMessage());
+			e.printStackTrace();
+			System.exit(-1);
+		}
+		double dist = distDemo.distance.getValue().doubleValue();
+		dist = Math.sqrt(dist);
+		System.out.println("Distance between party 1 and 2 is " + dist);
+	}
+
+}

--- a/src/main/java/dk/alexandra/fresco/demo/DistanceDemo.java
+++ b/src/main/java/dk/alexandra/fresco/demo/DistanceDemo.java
@@ -44,7 +44,7 @@ import dk.alexandra.fresco.lib.helper.builder.NumericIOBuilder;
 import dk.alexandra.fresco.lib.helper.builder.NumericProtocolBuilder;
 
 /**
- * A simple demo the distance between two secret points
+ * A simple demo computing the distance between two secret points
  */
 public class DistanceDemo implements Application {
 	
@@ -72,7 +72,7 @@ public class DistanceDemo implements Application {
 			x2 = (myId == 2) ? iob.input(myX, 2) : iob.input(2); 
 			y2 = (myId == 2) ? iob.input(myY, 2) : iob.input(2); 
 		iob.endCurScope();
-		// Compute distance
+		// Compute distance squared (note, square root computation can be done publicly)
 		npb.beginParScope();
 			npb.beginSeqScope();
 				SInt dX = npb.sub(x1, x2);

--- a/src/main/java/dk/alexandra/fresco/framework/configuration/CmdLineUtil.java
+++ b/src/main/java/dk/alexandra/fresco/framework/configuration/CmdLineUtil.java
@@ -57,24 +57,24 @@ import dk.alexandra.fresco.suite.bgw.configuration.BgwConfiguration;
 import dk.alexandra.fresco.suite.dummy.DummyConfiguration;
 import dk.alexandra.fresco.suite.spdz.configuration.SpdzConfiguration;
 
-
 /**
  * Utility for reading all configuration from command line.
- * 
+ * <p>
  * A set of default configurations are used when parameters are not specified at runtime.
+ * </p>
  * 
  */
 public class CmdLineUtil {
 
 	private final Options options;
+	private Options appOptions;
 	private CommandLine cmd;
-	
 	private SCEConfiguration sceConf;
 	private ProtocolSuiteConfiguration psConf;
 	
 	public CmdLineUtil() {
+		this.appOptions = new Options();
 		this.options = buildStandardOptions();
-	
 	}
 	
 	public SCEConfiguration getSCEConfiguration() {
@@ -86,16 +86,6 @@ public class CmdLineUtil {
 	}
 	
 	/**
-	 * To be called after parse(). Returns remaining arguments that can be used for the specific application.
-	 * 
-	 * @return The arguments that are not for SCE and protocol suite.
-	 * 
-	 */
-	public String[] getRemainingArgs() {
-		return this.cmd.getArgs();
-	}
-	
-	/**
 	 * Adds standard options.
 	 * 
 	 * TODO: Move standard options to SCE.
@@ -103,22 +93,14 @@ public class CmdLineUtil {
 	 * For instance, options for setting player id and protocol suite.
 	 * 
 	 */
-	private Options buildStandardOptions() {
+	private static Options buildStandardOptions() {
 		Options options = new Options();
-
-		options.addOption(Option.builder("h")
-				.desc("Displays this help message")
-				.longOpt("help")
-				.required(false)
-				.hasArg(false)
-				.build());
 		
 		options.addOption(Option.builder("i")
 				.desc("The id of this player. Must be a unique positive integer.")
 				.longOpt("id")
 				.required(true)
 				.hasArg()
-				 //.type(Integer.class) // Dosn't work for some reason.
 				.build());
 		
 		options.addOption(Option.builder("s")
@@ -130,18 +112,17 @@ public class CmdLineUtil {
 				.hasArg()
 				.build());
 		
-		options.addOption(Option.builder("p")
-			.desc("Connection data for a party. Use -p multiple times to specify many players. You must always at least include yourself."
+		options.addOption(Option.builder("p")	
+				.desc("Connection data for a party. Use -p multiple times to specify many players. You must always at least include yourself."
 					+ "Must be on the form [id]:[hostname]:[port] or [id]:[hostname]:[port]:[shared key]. "
 					+ "id is a unique positive integer for the player, host and port is where to find the player, "
 					+ " shared key is an optional string defining a secret key that is shared by you and the other player "
 					+ " (the other player must submit the same key for you as you do for him). "
 					)
-			.longOpt("party")
-			.required(true)
-			.hasArgs()
-			.build());
-
+				.longOpt("party")
+				.required(true)
+				.hasArgs()
+				.build());
 		
 		options.addOption(Option.builder("l")
 				.desc("The log level. Can be either OFF, SEVERE, CONFIG, WARNING, INFO, FINE, FINER, FINEST. Default is 'WARNING'")
@@ -177,20 +158,21 @@ public class CmdLineUtil {
 				.required(false)
 				.hasArg(true)
 				.build());
+		
 		options.addOption(Option.builder("D")
 				.argName("property=value")
-				.desc("Use for special properties")
+				.desc("Used to set properties of protocol suite and other customizable components.")
 				.required(false)
 				.hasArg()
 				.numberOfArgs(2)
 				.valueSeparator()
-				.build());	
+				.build());
 		
 		return options;
 	}
 	
 	
-	private int getDefaultNoOfThreads() {
+	private static int getDefaultNoOfThreads() {
 		int n = Runtime.getRuntime().availableProcessors();
 		if (n==1) return 1;
 		// Heuristic that gives best performance: One thread for each worker 
@@ -213,18 +195,15 @@ public class CmdLineUtil {
 	}
 
 	private void validateStandardOptions() throws ParseException {
-		
 		int myId;
 		Level logLevel;
 		
 		Object suiteObj = this.cmd.getParsedOptionValue("s");
 		if (suiteObj == null) throw new ParseException("Cannot parse '" + this.cmd.getOptionValue("s") + "' as a string");
-		
-		
+				
 		final Map<Integer,Party> parties = new HashMap<Integer,Party>();
 		final String suite = (String) suiteObj;
-		
-		
+				
 		if (!ProtocolSuite.getSupportedProtocolSuites().contains(suite.toLowerCase()))
 			throw new ParseException("Unknown protocol suite: " + suite);
 		
@@ -246,14 +225,15 @@ public class CmdLineUtil {
 					party = new Party(id, p[1], port, p[3]);
 				}
 				if (parties.containsKey(id))
-					throw new ParseException("Player ids must be unique");
+					throw new ParseException("Party ids must be unique");
 				parties.put(id, party);
 			} catch (NumberFormatException | UnknownHostException e) {
 				throw new ParseException("Could not parse '" + pStr + "': " + e.getMessage());
 			}
 		}
 		if (!parties.containsKey(myId))
-			throw new ParseException("You must at least include yourself in the list of players");
+			throw new ParseException("This party is given the id " + myId + 
+					" but this id is not present in the list of parties " + parties.keySet());
 		
 
 		if (this.cmd.hasOption("l")) {
@@ -306,8 +286,7 @@ public class CmdLineUtil {
 			}
 		} else {
 			maxBatchSize = 4096;
-		}
-		
+		}		
 		
 		// TODO: Rather: Just log sceConf.toString()
 		Reporter.config("Player id          : " + myId);
@@ -384,28 +363,39 @@ public class CmdLineUtil {
 	 * 
 	 */
 	public void addOption(Option option) {
-		// TODO: Rather, application specific options.
-		this.options.addOption(option);
+		this.appOptions.addOption(option);
 	}
 	
 	public CommandLine parse(String[] args) {
-		//System.out.println("Got args: " + Arrays.toString(args));
 		try {
 			CommandLineParser parser = new DefaultParser();
-			this.cmd = parser.parse(options, args, false);
+			Options helpOpt = new Options();
+			helpOpt.addOption(Option.builder("h")
+					.desc("Displays this help message")
+					.longOpt("help")
+					.required(false)
+					.hasArg(false)
+					.build());
 			
+			cmd = parser.parse(helpOpt, args, true);
 			if (cmd.hasOption("h")) {
 				displayHelp();
 				System.exit(0);
 			}
-			validateStandardOptions();
+			Options allOpts = new Options();
+			for (Option o : options.getOptions()) {
+				allOpts.addOption(o);
+			}
+			for (Option o : appOptions.getOptions()) {
+				allOpts.addOption(o);
+			}			
+			cmd = parser.parse(allOpts, args);
 			
+			validateStandardOptions();
 			// TODO: Do this without hardcoding the protocol suite names here.
-			String[] remainingArgs = null;// = cmd.getArgs();
 			switch (this.sceConf.getProtocolSuiteName()) {
 			case "bgw":
-				//this.psConf = BgwConfiguration.fromCmdArgs(this.sceConf, remainingArgs);
-				this.psConf = BgwConfiguration.fromCmdLine(sceConf, cmd);
+				this.psConf = BgwConfiguration.fromCmdLine(this.sceConf, cmd);
 				break;
 			case "dummy":
 				this.psConf = DummyConfiguration.fromCmdLine(this.sceConf, cmd);
@@ -414,34 +404,8 @@ public class CmdLineUtil {
 				this.psConf = SpdzConfiguration.fromCmdLine(this.sceConf, cmd);
 				break;
 			default:
-				throw new IllegalArgumentException("Unknown protocol suite: " + this.getSCEConfiguration().getProtocolSuiteName());
-			}
-//			
-//			if (cmd.hasOption("v")) {
-//				log.log(Level.INFO, "Using cli argument -v=" + cmd.getOptionValue("v"));
-//				// Whatever you want to do with the setting goes here
-//			} else {
-//				log.log(Level.SEVERE, "MIssing v option");
-//				help();
-//			}		
-			
-//			// Parse input from cmd line
-//			// TODO: We want to run both player 1 and 2 from same place, so we override player id.
-//			int myId = Integer.parseInt(args[0]);
-//			boolean[] in = null;
-//			if (args[1].length() != 16)
-//				throw new IllegalArgumentException("bad input hex string or player id");
-//			if (myId == 1 || myId == 2) {
-//				in = toBoolean(args[1]);
-//			}
-//			// Do the secure computation using config from property files.
-//			CmdLineUtil aes = new CmdLineUtil(myId, in);
-//			SCE sce = SCE.getInstance(myId);
-//			sce.runApplication(aes);
-//			
-//			// Print result.
-//			System.out.println("The resulting ciphertext is: " + Arrays.toString(aes.result));
-			
+				throw new ParseException("Unknown protocol suite: " + this.getSCEConfiguration().getProtocolSuiteName());
+			}			
 		} catch (ParseException e) {
 			System.out.println("Error while parsing arguments: " + e.getLocalizedMessage());
 			System.out.println();
@@ -453,7 +417,10 @@ public class CmdLineUtil {
 
 	public void displayHelp() {
 		HelpFormatter formatter = new HelpFormatter();
-		formatter.printHelp("general options are:", this.options);
+		formatter.setSyntaxPrefix("");
+		formatter.printHelp("General SCE options are:", this.options);
+		formatter.setSyntaxPrefix("");
+		formatter.printHelp("Application specific options are:", this.appOptions);
 	}
 
 }

--- a/src/main/java/dk/alexandra/fresco/framework/configuration/CmdLineUtil.java
+++ b/src/main/java/dk/alexandra/fresco/framework/configuration/CmdLineUtil.java
@@ -41,7 +41,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import dk.alexandra.fresco.framework.MPCException;
 import dk.alexandra.fresco.framework.Party;
 import dk.alexandra.fresco.framework.ProtocolEvaluator;
 import dk.alexandra.fresco.framework.Reporter;
@@ -178,6 +177,14 @@ public class CmdLineUtil {
 				.required(false)
 				.hasArg(true)
 				.build());
+		options.addOption(Option.builder("D")
+				.argName("property=value")
+				.desc("Use for special properties")
+				.required(false)
+				.hasArg()
+				.numberOfArgs(2)
+				.valueSeparator()
+				.build());	
 		
 		return options;
 	}
@@ -186,7 +193,9 @@ public class CmdLineUtil {
 	private int getDefaultNoOfThreads() {
 		int n = Runtime.getRuntime().availableProcessors();
 		if (n==1) return 1;
-		return n-1; // Heuristic that gives best performance: One thread for each worker and one for the 'system'.
+		// Heuristic that gives best performance: One thread for each worker 
+		// and one for the 'system'.
+		return n-1; 
 	}
 	
 	private int parseNonzeroInt(String optionId) throws ParseException {
@@ -369,8 +378,7 @@ public class CmdLineUtil {
 			};
 
 	}
-	
-	
+		
 	/**
 	 * For adding application specific options.
 	 * 
@@ -380,43 +388,34 @@ public class CmdLineUtil {
 		this.options.addOption(option);
 	}
 	
-	
-
-	
 	public CommandLine parse(String[] args) {
 		//System.out.println("Got args: " + Arrays.toString(args));
 		try {
 			CommandLineParser parser = new DefaultParser();
-			this.cmd = parser.parse(options, args);
+			this.cmd = parser.parse(options, args, false);
 			
 			if (cmd.hasOption("h")) {
 				displayHelp();
 				System.exit(0);
 			}
-
-			
 			validateStandardOptions();
-
-			
-			
 			
 			// TODO: Do this without hardcoding the protocol suite names here.
-			String[] remainingArgs = cmd.getArgs();
+			String[] remainingArgs = null;// = cmd.getArgs();
 			switch (this.sceConf.getProtocolSuiteName()) {
 			case "bgw":
-				this.psConf = BgwConfiguration.fromCmdArgs(this.sceConf, remainingArgs);
+				//this.psConf = BgwConfiguration.fromCmdArgs(this.sceConf, remainingArgs);
+				this.psConf = BgwConfiguration.fromCmdLine(sceConf, cmd);
 				break;
 			case "dummy":
-				this.psConf = DummyConfiguration.fromCmdArgs(this.sceConf, remainingArgs);
+				this.psConf = DummyConfiguration.fromCmdLine(this.sceConf, cmd);
 				break;
 			case "spdz":
-				this.psConf = SpdzConfiguration.fromCmdArgs(this.sceConf, remainingArgs);
+				this.psConf = SpdzConfiguration.fromCmdLine(this.sceConf, cmd);
 				break;
 			default:
-				throw new MPCException("Unknown protocol suite: " + this.getSCEConfiguration().getProtocolSuiteName());
+				throw new IllegalArgumentException("Unknown protocol suite: " + this.getSCEConfiguration().getProtocolSuiteName());
 			}
-	
-
 //			
 //			if (cmd.hasOption("v")) {
 //				log.log(Level.INFO, "Using cli argument -v=" + cmd.getOptionValue("v"));
@@ -424,9 +423,7 @@ public class CmdLineUtil {
 //			} else {
 //				log.log(Level.SEVERE, "MIssing v option");
 //				help();
-//			}
-
-			
+//			}		
 			
 //			// Parse input from cmd line
 //			// TODO: We want to run both player 1 and 2 from same place, so we override player id.
@@ -450,23 +447,13 @@ public class CmdLineUtil {
 			System.out.println();
 			displayHelp();
 			System.exit(-1); // TODO: Consider moving to top level.
-			
 		}
 		return this.cmd;
-
-
 	}
 
-
-	
-
-	
-	
 	public void displayHelp() {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.printHelp("general options are:", this.options);
 	}
-	
 
-	
 }

--- a/src/main/java/dk/alexandra/fresco/lib/lp/LPSolverProtocol.java
+++ b/src/main/java/dk/alexandra/fresco/lib/lp/LPSolverProtocol.java
@@ -32,7 +32,6 @@ import dk.alexandra.fresco.framework.MPCException;
 import dk.alexandra.fresco.framework.NativeProtocol;
 import dk.alexandra.fresco.framework.Protocol;
 import dk.alexandra.fresco.framework.ProtocolProducer;
-import dk.alexandra.fresco.framework.util.GateRegister;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.framework.value.Value;

--- a/src/main/java/dk/alexandra/fresco/suite/bgw/configuration/BgwConfiguration.java
+++ b/src/main/java/dk/alexandra/fresco/suite/bgw/configuration/BgwConfiguration.java
@@ -47,52 +47,33 @@ public interface BgwConfiguration extends ProtocolSuiteConfiguration {
 	 * 
 	 */
 	int getThreshold();
-	
+
 	/**
 	 * 
 	 * @return The modulus used in BGW
 	 */
 	BigInteger getModulus();
-	
-	/// Here comes methods for BGW specific parameters and their validation.
-	
-	
-	public static BgwConfiguration fromCmdArgs(SCEConfiguration sceConf, String[] args) throws ParseException {
-		Options options = new Options();
 
-		options.addOption(Option.builder("D")
-				.desc("The threshold security level. Must be a positive integer, must be at most n/2.")
-				.longOpt("bgw.threshold")
-				.required(true)
-				.hasArgs()
-				.build());		
-		
-		options.addOption(Option.builder("D")
-				.desc("The modulus of the field you want to work in. i.e. the field size")
-				.longOpt("bgw.modulus")
-				.required(false)
-				.hasArgs()
-				.build());
-		
-		CommandLineParser parser = new DefaultParser();
-		CommandLine cmd = parser.parse(options, args);
-		
+	/// Here comes methods for BGW specific parameters and their validation.
+	public static BgwConfiguration fromCmdLine(SCEConfiguration sceConf, CommandLine cmd) throws ParseException {
 		// Validate BGW specific arguments.
 		Properties p = cmd.getOptionProperties("D");
-		if (!p.contains("bgw.threshold")) {
-			throw new ParseException("BGW requires you to specify -Dbgw.threshold=[int]");
-		}		
-		
+		if (!p.containsKey("bgw.threshold")) {
+			throw new ParseException("BGW requires setting -Dbgw.threshold=[int]");
+		}
+
 		try {
-			final int threshold = Integer.parseInt(p.getProperty("bgw.threshold"));			
-			if (threshold < 1) throw new ParseException("bgw.threshold must be > 0");
-			if (threshold > sceConf.getParties().size() / 2) throw new ParseException("bgw.threshold must be < n/2");		
-			
+			final int threshold = Integer.parseInt(p.getProperty("bgw.threshold"));
+			if (threshold < 1)
+				throw new ParseException("bgw.threshold must be > 0");
+			if (threshold > sceConf.getParties().size() / 2)
+				throw new ParseException("bgw.threshold must be < n/2");
+
 			final BigInteger modulus = new BigInteger(p.getProperty("bgw.modulus", "618970019642690137449562111"));
-			if(!modulus.isProbablePrime(40)) {
+			if (!modulus.isProbablePrime(40)) {
 				throw new ParseException("BGW Modulus must be a prime number");
 			}
-			
+
 			return new BgwConfiguration() {
 
 				@Override
@@ -104,17 +85,10 @@ public interface BgwConfiguration extends ProtocolSuiteConfiguration {
 				public BigInteger getModulus() {
 					return modulus;
 				}
-				
+
 			};
 		} catch (NumberFormatException e) {
 			throw new ParseException("Invalid bgw.threshold value: '" + p.getProperty("bgw.threshold") + "'");
 		}
-		
-		
-		//List<String> rest = cmd.getArgList(); // TODO: Pass back for use in application.
-		
-	
-		
 	}
-	
 }

--- a/src/main/java/dk/alexandra/fresco/suite/bgw/configuration/BgwConfiguration.java
+++ b/src/main/java/dk/alexandra/fresco/suite/bgw/configuration/BgwConfiguration.java
@@ -30,10 +30,6 @@ import java.math.BigInteger;
 import java.util.Properties;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
@@ -54,7 +50,7 @@ public interface BgwConfiguration extends ProtocolSuiteConfiguration {
 	 */
 	BigInteger getModulus();
 
-	/// Here comes methods for BGW specific parameters and their validation.
+	// Here comes methods for BGW specific parameters and their validation.
 	public static BgwConfiguration fromCmdLine(SCEConfiguration sceConf, CommandLine cmd) throws ParseException {
 		// Validate BGW specific arguments.
 		Properties p = cmd.getOptionProperties("D");
@@ -91,4 +87,5 @@ public interface BgwConfiguration extends ProtocolSuiteConfiguration {
 			throw new ParseException("Invalid bgw.threshold value: '" + p.getProperty("bgw.threshold") + "'");
 		}
 	}
+
 }

--- a/src/main/java/dk/alexandra/fresco/suite/dummy/DummyConfiguration.java
+++ b/src/main/java/dk/alexandra/fresco/suite/dummy/DummyConfiguration.java
@@ -26,14 +26,15 @@
  *******************************************************************************/
 package dk.alexandra.fresco.suite.dummy;
 
+import org.apache.commons.cli.CommandLine;
+
 import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
 import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
 
 public class DummyConfiguration implements ProtocolSuiteConfiguration {
 
-	public static ProtocolSuiteConfiguration fromCmdArgs(SCEConfiguration sceConf, String[] remainingArgs) {
+	public static ProtocolSuiteConfiguration fromCmdLine(SCEConfiguration sceConf, CommandLine cmd) {
 		return new DummyConfiguration();
 	}
-
 	
 }

--- a/src/main/java/dk/alexandra/fresco/suite/spdz/configuration/SpdzConfiguration.java
+++ b/src/main/java/dk/alexandra/fresco/suite/spdz/configuration/SpdzConfiguration.java
@@ -29,10 +29,6 @@ package dk.alexandra.fresco.suite.spdz.configuration;
 import java.util.Properties;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
@@ -41,8 +37,12 @@ import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
 public interface SpdzConfiguration extends ProtocolSuiteConfiguration {
 
 	/**
-	 * 
-	 * @return The maximum bit length of any number in the field. It should be possible to multiply two numbers without overflow
+	 * Gets an approximation of the maximum bit length of any number appearing 
+	 * in an application. This is used by certain protocols, e.g., to avoid overflow 
+	 * when working in a Z_p field. 
+	 * TODO: Consider factoring out of the configuration as this is really specific
+	 * only to certain protocols.
+	 * @return the expected maximum bit length of any number appearing in the application.
 	 */
 	int getMaxBitLength();
 
@@ -63,20 +63,12 @@ public interface SpdzConfiguration extends ProtocolSuiteConfiguration {
 	
 	static SpdzConfiguration fromCmdLine(SCEConfiguration sceConf,
 			CommandLine cmd) throws ParseException {
-		// Validate SPDZ specific arguments.
 		Properties p = cmd.getOptionProperties("D");
-		
-		if (!p.containsKey("spdz.securityParameter")) {
-			throw new ParseException(
-					"SPDZ requires you to specify -Dspdz.securityParameter=[path]");
-		}
-				
-		final int maxBitLength = Integer.parseInt(p
-				.getProperty("spdz.maxBitLength"));
+		//TODO: Figure out a meaningful default for the below 
+		final int maxBitLength = Integer.parseInt(p.getProperty("spdz.maxBitLength", "64"));
 		if (maxBitLength < 2) {
 			throw new ParseException("spdz.maxBitLength must be > 1");
 		}
-
 		final String triplePath = p.getProperty("spdz.triplePath", "/triples");
 		final boolean useDummyData = Boolean.parseBoolean(p.getProperty("spdz.useDummyData", "False"));
 

--- a/src/main/java/dk/alexandra/fresco/suite/spdz/configuration/SpdzConfiguration.java
+++ b/src/main/java/dk/alexandra/fresco/suite/spdz/configuration/SpdzConfiguration.java
@@ -61,32 +61,12 @@ public interface SpdzConfiguration extends ProtocolSuiteConfiguration {
 	 */
 	public boolean useDummyData();
 	
-	static SpdzConfiguration fromCmdArgs(SCEConfiguration sceConf,
-			String[] remainingArgs) throws ParseException {
-		Options options = new Options();
-
-		options.addOption(Option
-				.builder("D")
-				.desc("The path to where the preprocessed data is located - e.g. the triples. Defaults to '/triples'")
-				.longOpt("spdz.triplePath").required(false).hasArgs().build());
-
-		options.addOption(Option
-				.builder("D")
-				.desc("The maximum bit length. A suggestion is half the size of the modulus, but might be required to be lower for some applications.")
-				.longOpt("spdz.maxBitLength").required(true).hasArgs().build());
-		
-		options.addOption(Option
-				.builder("D")
-				.desc("Set to true to use dummy data as preprocessed data.")
-				.longOpt("spdz.useDummyData").required(false).hasArgs().build());
-
-		CommandLineParser parser = new DefaultParser();
-		CommandLine cmd = parser.parse(options, remainingArgs);
-
-		// Validate BGW specific arguments.
+	static SpdzConfiguration fromCmdLine(SCEConfiguration sceConf,
+			CommandLine cmd) throws ParseException {
+		// Validate SPDZ specific arguments.
 		Properties p = cmd.getOptionProperties("D");
 		
-		if (!p.contains("spdz.securityParameter")) {
+		if (!p.containsKey("spdz.securityParameter")) {
 			throw new ParseException(
 					"SPDZ requires you to specify -Dspdz.securityParameter=[path]");
 		}

--- a/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzLPSolver2Parties.java
+++ b/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzLPSolver2Parties.java
@@ -55,7 +55,6 @@ import dk.alexandra.fresco.suite.spdz.evaluation.strategy.SpdzProtocolSuite;
 import dk.alexandra.fresco.suite.spdz.storage.InitializeStorage;
 
 public class TestSpdzLPSolver2Parties {
-
 	
 	private void runTest(TestThreadFactory f, int noPlayers, int noOfVmThreads,
 			EvaluationStrategy evalStrategy, StorageStrategy storageStrategy, boolean useDummyData)
@@ -114,6 +113,9 @@ public class TestSpdzLPSolver2Parties {
 			conf.put(playerId, ttc);
 		}
 		TestThreadRunner.run(f, conf);
+		for (int i : conf.keySet()) {
+			SpdzProtocolSuite.getInstance(i).destroy();
+		}
 	}
 
 	private static final InMemoryStorage inMemStore = new InMemoryStorage();


### PR DESCRIPTION
Fixes problems pointed out on the mailing list in the command line utility where configurations of most protocol suites was not done correctly. 

Additionally: 

- adds a simple demo application using the commandline utility. The demo application simply computes the distance between two points in two-dimensional space given by the parties. 

- fixes a problem that could cause tests to be run in parallel.