### PR TITLE
Fix quickstart documentation: getRemainingArgs() no longer exists.

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -61,12 +61,12 @@ code:
 
             // Read FRESCO configuration from command line args.
             CmdLineUtil util = new CmdLineUtil();
-            util.parse(args);
+            CommandLine parsedCommandLine = util.parse(args);
             SCEConfiguration sceConf = util.getSCEConfiguration();
             ProtocolSuiteConfiguration psConf = util.getProtocolSuiteConfiguration();
 
 	    // Read and parse key or plaintext.
-            String in = util.getRemainingArgs()[0];
+            String in = parsedCommandLine.getArgs()[0];
             boolean[] input = ByteArithmetic.toBoolean(in);
 
             // Run secure computation.

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -42,6 +42,7 @@ code:
     import dk.alexandra.fresco.lib.helper.sequential.SequentialProtocolProducer;
     import dk.alexandra.fresco.lib.crypto.BristolCryptoFactory;
 
+    import org.apache.commons.cli.CommandLine;
 
     public class AESDemo implements Application {
 


### PR DESCRIPTION
When trying the example code from the quickstart documentation, I got a compilation error. This should fix that.