### PR TITLE
Bugfix: SPDZ MAC checks

### DIFF
--- a/src/main/java/dk/alexandra/fresco/suite/spdz/evaluation/strategy/SpdzProtocolSuite.java
+++ b/src/main/java/dk/alexandra/fresco/suite/spdz/evaluation/strategy/SpdzProtocolSuite.java
@@ -27,30 +27,23 @@
 package dk.alexandra.fresco.suite.spdz.evaluation.strategy;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Random;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import dk.alexandra.fresco.framework.MPCException;
-import dk.alexandra.fresco.framework.NativeProtocol.EvaluationStatus;
+import dk.alexandra.fresco.framework.NativeProtocol;
 import dk.alexandra.fresco.framework.Reporter;
-import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.network.SCENetworkImpl;
 import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
+import dk.alexandra.fresco.framework.sce.evaluator.BatchedStrategy;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.suite.ProtocolSuite;
 import dk.alexandra.fresco.suite.spdz.configuration.SpdzConfiguration;
-import dk.alexandra.fresco.suite.spdz.datatypes.SpdzCommitment;
-import dk.alexandra.fresco.suite.spdz.datatypes.SpdzElement;
-import dk.alexandra.fresco.suite.spdz.gates.SpdzCommitProtocol;
-import dk.alexandra.fresco.suite.spdz.gates.SpdzOpenCommitProtocol;
+import dk.alexandra.fresco.suite.spdz.gates.SpdzMacCheckProtocol;
 import dk.alexandra.fresco.suite.spdz.storage.SpdzStorage;
 import dk.alexandra.fresco.suite.spdz.storage.SpdzStorageDummyImpl;
 import dk.alexandra.fresco.suite.spdz.storage.SpdzStorageImpl;
@@ -60,8 +53,7 @@ public class SpdzProtocolSuite implements ProtocolSuite {
 
 	private static Map<Integer, SpdzProtocolSuite> instances;
 
-	private Network network;
-	private Random rand;
+	private SecureRandom rand;
 	private SpdzStorage[] store;
 	private ResourcePool rp;
 	private int gatesEvaluated = 0;
@@ -69,7 +61,14 @@ public class SpdzProtocolSuite implements ProtocolSuite {
 	private BigInteger keyShare, p;
 	private MessageDigest[] digs;
 	private SpdzConfiguration spdzConf;
-
+	
+	//This is set whenever an output protocol was evaluated. It means that the sync point needs to do a MAC check.
+	private boolean outputProtocolInBatch = false;
+	
+	public void outputProtocolUsedInBatch() {
+		outputProtocolInBatch = true;
+	}
+	
 	public SpdzProtocolSuite() {
 	}
 
@@ -106,7 +105,6 @@ public class SpdzProtocolSuite implements ProtocolSuite {
 	@Override
 	public void init(ResourcePool resourcePool, ProtocolSuiteConfiguration conf) {
 		spdzConf = (SpdzConfiguration) conf;
-		this.network = resourcePool.getNetwork();
 		int noOfThreads = resourcePool.getVMThreadCount();
 		this.store = new SpdzStorage[noOfThreads];
 		for (int i = 0; i < noOfThreads; i++) {
@@ -149,7 +147,7 @@ public class SpdzProtocolSuite implements ProtocolSuite {
 	@Override
 	public void synchronize(int gatesEvaluated) throws MPCException {
 		this.gatesEvaluated += gatesEvaluated;
-		if (this.gatesEvaluated > macCheckThreshold) {
+		if (this.gatesEvaluated > macCheckThreshold || outputProtocolInBatch) {
 			try {
 				for (int i = 1; i < store.length; i++) {
 					store[0].getOpenedValues().addAll(store[i].getOpenedValues());
@@ -175,179 +173,23 @@ public class SpdzProtocolSuite implements ProtocolSuite {
 	}
 
 	private void MACCheck() throws IOException {
-		// TODO: This is not truly random
-		BigInteger s = new BigInteger(Util.getModulus().bitLength(), rand).mod(Util.getModulus());
-		SpdzCommitment commitment = new SpdzCommitment(this.digs[0], s, rand);
-		Map<Integer, BigInteger> comms = new HashMap<Integer, BigInteger>();
-		SpdzCommitProtocol comm = new SpdzCommitProtocol(commitment, comms);
-		Map<Integer, BigInteger> ss = new HashMap<Integer, BigInteger>();
-		SpdzOpenCommitProtocol open = new SpdzOpenCommitProtocol(commitment, comms, ss);
-
-		SCENetworkImpl protocolNetwork = new SCENetworkImpl(this.rp.getNoOfParties(), 0);
-
-		EvaluationStatus status;
-		int i = 0;
+		SpdzMacCheckProtocol macCheck = new SpdzMacCheckProtocol(rand, this.digs[0], store[0]);
+		
+		int batchSize = 128;
+		NativeProtocol[] nextProtocols = new NativeProtocol[batchSize];
+		SCENetworkImpl[] sceNetworks = new SCENetworkImpl[batchSize];
+		for (int i = 0; i < batchSize; i++) {
+			sceNetworks[i] = new SCENetworkImpl(this.rp.getNoOfParties(), 0);
+		}
+		
 		do {
-			status = comm.evaluate(i, this.rp, protocolNetwork);
-			i++;
-			// send phase
-			Map<Integer, Queue<Serializable>> output = protocolNetwork.getOutputFromThisRound();
-			for (int pId : output.keySet()) {
-				// send array since queue is not serializable
-				network.send("0", pId, output.get(pId).toArray(new Serializable[0]));
-			}
-
-			// receive phase
-			Map<Integer, Queue<Serializable>> inputForThisRound = new HashMap<Integer, Queue<Serializable>>();
-			for (int pId : protocolNetwork.getExpectedInputForNextRound()) {
-				Serializable[] messages = network.receive("0", pId);
-				Queue<Serializable> q = new LinkedBlockingQueue<Serializable>();
-				// convert back from array to queue.
-				for (Serializable message : messages) {
-					q.offer(message);
-				}
-				inputForThisRound.put(pId, q);
-			}
-			protocolNetwork.setInput(inputForThisRound);
-			protocolNetwork.nextRound();
-		} while (status != EvaluationStatus.IS_DONE);
-
-		i = 0;
-		do {
-			status = open.evaluate(i, this.rp, protocolNetwork);
-			i++;
-			// send phase
-			Map<Integer, Queue<Serializable>> output = protocolNetwork.getOutputFromThisRound();
-			for (int pId : output.keySet()) {
-				// send array since queue is not serializable
-				network.send("0", pId, output.get(pId).toArray(new Serializable[0]));
-			}
-
-			// receive phase
-			Map<Integer, Queue<Serializable>> inputForThisRound = new HashMap<Integer, Queue<Serializable>>();
-			for (int pId : protocolNetwork.getExpectedInputForNextRound()) {
-				Serializable[] messages = network.receive("0", pId);
-				Queue<Serializable> q = new LinkedBlockingQueue<Serializable>();
-				// convert back from array to queue.
-				for (Serializable message : messages) {
-					q.offer(message);
-				}
-				inputForThisRound.put(pId, q);
-			}
-			protocolNetwork.setInput(inputForThisRound);
-			protocolNetwork.nextRound();
-		} while (status != EvaluationStatus.IS_DONE);
-
-		// Add all s's to get the common random value:
-		s = BigInteger.ZERO;
-		for (BigInteger otherS : ss.values()) {
-			s = s.add(otherS);
-		}
-
-		// TODO: Need to gather all values from all stores in a smart manner
-		// that makes the check good.
-		List<BigInteger> as = this.store[0].getOpenedValues();
-		int t = as.size();
-
-		BigInteger[] rs = new BigInteger[t];
-		MessageDigest H = new Util().getHashFunction();
-		BigInteger r_temp = s;
-		for (i = 0; i < t; i++) {
-			r_temp = new BigInteger(H.digest(r_temp.toByteArray())).mod(Util.getModulus());
-			rs[i] = r_temp;
-		}
-		BigInteger a = BigInteger.ZERO;
-		int index = 0;
-		for (BigInteger aa : as) {
-			a = a.add(aa.multiply(rs[index++])).mod(Util.getModulus());
-		}
-		// compute gamma_i as the sum of all MAC's on the opened values times
-		// r_j.
-		List<SpdzElement> closedValues = store[0].getClosedValues();
-		if (closedValues.size() != t) {
-			throw new MPCException(
-					"Amount of closed values does not equal the amount of partially opened values. Aborting!");
-		}
-		BigInteger gamma = BigInteger.ZERO;
-		index = 0;
-		for (SpdzElement c : closedValues) {
-			gamma = gamma.add(rs[index++].multiply(c.getMac())).mod(Util.getModulus());
-		}
-
-		// compute delta_i as: gamma_i - alpha_i*a
-		BigInteger delta = gamma.subtract(store[0].getSSK().multiply(a)).mod(Util.getModulus());
-		// Commit to delta and open it afterwards
-		commitment = new SpdzCommitment(this.digs[0], delta, rand);
-		comms = new HashMap<Integer, BigInteger>();
-		comm = new SpdzCommitProtocol(commitment, comms);
-		ss = new HashMap<Integer, BigInteger>();
-		open = new SpdzOpenCommitProtocol(commitment, comms, ss);
-
-		status = null;
-		i = 0;
-		do {
-			status = comm.evaluate(i, this.rp, protocolNetwork);
-			i++;
-			// send phase
-			Map<Integer, Queue<Serializable>> output = protocolNetwork.getOutputFromThisRound();
-			for (int pId : output.keySet()) {
-				// send array since queue is not serializable
-				network.send("0", pId, output.get(pId).toArray(new Serializable[0]));
-			}
-
-			// receive phase
-			Map<Integer, Queue<Serializable>> inputForThisRound = new HashMap<Integer, Queue<Serializable>>();
-			for (int pId : protocolNetwork.getExpectedInputForNextRound()) {
-				Serializable[] messages = network.receive("0", pId);
-				Queue<Serializable> q = new LinkedBlockingQueue<Serializable>();
-				// convert back from array to queue.
-				for (Serializable message : messages) {
-					q.offer(message);
-				}
-				inputForThisRound.put(pId, q);
-			}
-			protocolNetwork.setInput(inputForThisRound);
-			protocolNetwork.nextRound();
-		} while (status != EvaluationStatus.IS_DONE);
-
-		i = 0;
-		do {
-			status = open.evaluate(i, this.rp, protocolNetwork);
-			i++;
-			// send phase
-			Map<Integer, Queue<Serializable>> output = protocolNetwork.getOutputFromThisRound();
-			for (int pId : output.keySet()) {
-				// send array since queue is not serializable
-				network.send("0", pId, output.get(pId).toArray(new Serializable[0]));
-			}
-
-			// receive phase
-			Map<Integer, Queue<Serializable>> inputForThisRound = new HashMap<Integer, Queue<Serializable>>();
-			for (int pId : protocolNetwork.getExpectedInputForNextRound()) {
-				Serializable[] messages = network.receive("0", pId);
-				Queue<Serializable> q = new LinkedBlockingQueue<Serializable>();
-				// convert back from array to queue.
-				for (Serializable message : messages) {
-					q.offer(message);
-				}
-				inputForThisRound.put(pId, q);
-			}
-			protocolNetwork.setInput(inputForThisRound);
-			protocolNetwork.nextRound();
-		} while (status != EvaluationStatus.IS_DONE);
-
-		BigInteger deltaSum = BigInteger.ZERO;
-		for (BigInteger d : ss.values()) {
-			deltaSum = deltaSum.add(d);
-		}
-		deltaSum = deltaSum.mod(Util.getModulus());
-		if (!deltaSum.equals(BigInteger.ZERO)) {			
-			throw new MPCException("The sum of delta's was not 0. Someone was corrupting something amongst " + t
-					+ " macs. Sum was " + deltaSum.toString() + " Aborting!");
-		}
-		// clean up store before returning to evaluating such that we only
-		// evaluate the next macs, not those we already checked.
-		this.store[0].reset();
+			int numOfProtocolsInBatch = macCheck.getNextProtocols(nextProtocols, 0);		
+			BatchedStrategy.processBatch(nextProtocols, numOfProtocolsInBatch, sceNetworks, "0",
+					this.rp);		
+		} while (macCheck.hasNextProtocols());
+		
+		//reset boolean value
+		this.outputProtocolInBatch = false;		
 	}
 
 	@Override

--- a/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzMacCheckProtocol.java
+++ b/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzMacCheckProtocol.java
@@ -1,0 +1,144 @@
+package dk.alexandra.fresco.suite.spdz.gates;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dk.alexandra.fresco.framework.MPCException;
+import dk.alexandra.fresco.framework.NativeProtocol;
+import dk.alexandra.fresco.framework.Protocol;
+import dk.alexandra.fresco.framework.ProtocolProducer;
+import dk.alexandra.fresco.framework.value.Value;
+import dk.alexandra.fresco.lib.helper.sequential.SequentialProtocolProducer;
+import dk.alexandra.fresco.suite.spdz.datatypes.SpdzCommitment;
+import dk.alexandra.fresco.suite.spdz.datatypes.SpdzElement;
+import dk.alexandra.fresco.suite.spdz.storage.SpdzStorage;
+import dk.alexandra.fresco.suite.spdz.utils.Util;
+
+public class SpdzMacCheckProtocol implements Protocol {
+
+	private SecureRandom rand;
+	private MessageDigest digest;
+	private List<BigInteger> as;	
+	private List<SpdzElement> closedValues;
+	private SpdzStorage storage;
+	private BigInteger s;
+	private int round = 0;
+	private ProtocolProducer pp;	
+	
+	private Map<Integer, BigInteger> ss = new HashMap<Integer, BigInteger>();
+	
+	public SpdzMacCheckProtocol(SecureRandom rand, MessageDigest digest, SpdzStorage storage) {
+		super();
+		this.rand = rand;
+		this.digest = digest;		
+		this.storage = storage;
+	}
+
+	@Override
+	public int getNextProtocols(NativeProtocol[] protocols, int pos) {
+		
+		if(pp == null) {
+			if(round == 0) {								
+				BigInteger s = new BigInteger(Util.getModulus().bitLength(), rand).mod(Util.getModulus());
+				SpdzCommitment commitment = new SpdzCommitment(digest, s, rand);
+				Map<Integer, BigInteger> comms = new HashMap<Integer, BigInteger>();
+				SpdzCommitProtocol comm = new SpdzCommitProtocol(commitment, comms);
+				SpdzOpenCommitProtocol open = new SpdzOpenCommitProtocol(commitment, comms, ss);
+				
+				pp = new SequentialProtocolProducer(comm, open);
+			} else if(round == 1) {
+				BigInteger alpha = storage.getSSK();
+				this.as = storage.getOpenedValues();
+				this.closedValues = storage.getClosedValues();
+				
+				// Add all s's to get the common random value:
+				s = BigInteger.ZERO;
+				for (BigInteger otherS : ss.values()) {
+					s = s.add(otherS);
+				}
+	
+				int t = as.size();
+	
+				BigInteger[] rs = new BigInteger[t];
+				MessageDigest H = new Util().getHashFunction();
+				BigInteger r_temp = s;
+				for (int i = 0; i < t; i++) {
+					r_temp = new BigInteger(H.digest(r_temp.toByteArray())).mod(Util.getModulus());
+					rs[i] = r_temp;
+				}
+				BigInteger a = BigInteger.ZERO;
+				int index = 0;
+				for (BigInteger aa : as) {
+					a = a.add(aa.multiply(rs[index++])).mod(Util.getModulus());
+				}
+				
+				// compute gamma_i as the sum of all MAC's on the opened values times
+				// r_j.
+				if (closedValues.size() != t) {
+					throw new MPCException(
+							"Amount of closed values does not equal the amount of partially opened values. Aborting!");
+				}
+				BigInteger gamma = BigInteger.ZERO;
+				index = 0;
+				for (SpdzElement c : closedValues) {
+					gamma = gamma.add(rs[index++].multiply(c.getMac())).mod(Util.getModulus());
+				}
+
+				// compute delta_i as: gamma_i - alpha_i*a
+				BigInteger delta = gamma.subtract(alpha.multiply(a)).mod(Util.getModulus());
+				// Commit to delta and open it afterwards
+				SpdzCommitment commitment = new SpdzCommitment(digest, delta, rand);
+				Map<Integer, BigInteger> comms = new HashMap<Integer, BigInteger>();
+				SpdzCommitProtocol comm = new SpdzCommitProtocol(commitment, comms);
+				ss = new HashMap<Integer, BigInteger>();
+				SpdzOpenCommitProtocol open = new SpdzOpenCommitProtocol(commitment, comms, ss);
+				
+				pp = new SequentialProtocolProducer(comm, open);
+			} else if(round == 2) {
+				BigInteger deltaSum = BigInteger.ZERO;
+				for (BigInteger d : ss.values()) {
+					deltaSum = deltaSum.add(d);
+				}
+				deltaSum = deltaSum.mod(Util.getModulus());
+				if (!deltaSum.equals(BigInteger.ZERO)) {			
+					throw new MPCException("The sum of delta's was not 0. Someone was corrupting something amongst " + as.size()
+							+ " macs. Sum was " + deltaSum.toString() + " Aborting!");
+				}
+				// clean up store before returning to evaluating such that we only
+				// evaluate the next macs, not those we already checked.
+				this.storage.reset();
+				pp = new SequentialProtocolProducer();
+			}
+		}
+		if (pp.hasNextProtocols()){
+			pos = pp.getNextProtocols(protocols, pos);
+		}
+		else if (!pp.hasNextProtocols()){
+			round++;
+			pp = null;
+		}
+		return pos;
+	}
+
+	@Override
+	public boolean hasNextProtocols() {
+		return round < 3;
+	}
+
+	@Override
+	public Value[] getInputValues() {
+		return null;
+	}
+
+	@Override
+	public Value[] getOutputValues() {
+		return null;
+	}
+
+	
+
+}

--- a/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzOutputProtocol.java
+++ b/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzOutputProtocol.java
@@ -72,15 +72,15 @@ public class SpdzOutputProtocol extends SpdzNativeProtocol implements OpenIntPro
 	}
 
 	@Override
-	public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
-			SCENetwork network) {
-		SpdzProtocolSuite spdzpii = SpdzProtocolSuite
-				.getInstance(resourcePool.getMyId());
-		int myId = resourcePool.getMyId();		
-		SpdzStorage storage = spdzpii.getStore(network.getThreadId());		
+	public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {		
+		SpdzProtocolSuite spdzpii = SpdzProtocolSuite.getInstance(resourcePool.getMyId());
+		spdzpii.outputProtocolUsedInBatch();
 		
+		int myId = resourcePool.getMyId();
+		SpdzStorage storage = spdzpii.getStore(network.getThreadId());
+
 		switch (round) {
-		case 0: 
+		case 0:
 			this.mask = storage.getSupplier().getNextInputMask(target_player);
 			SpdzElement inMinusMask = this.in.value.subtract(this.mask.getMask());
 			storage.addClosedValue(inMinusMask);
@@ -95,7 +95,7 @@ public class SpdzOutputProtocol extends SpdzNativeProtocol implements OpenIntPro
 			}
 			openedVal = openedVal.mod(Util.getModulus());
 			storage.addOpenedValue(openedVal);
-			if(target_player == myId) {
+			if (target_player == myId) {
 				openedVal = openedVal.add(this.mask.getRealValue());
 				BigInteger tmpOut = openedVal;
 				tmpOut = Util.convertRepresentation(tmpOut);
@@ -104,7 +104,7 @@ public class SpdzOutputProtocol extends SpdzNativeProtocol implements OpenIntPro
 			return EvaluationStatus.IS_DONE;
 		default:
 			throw new MPCException("No more rounds to evaluate.");
-		}		
+		}
 	}
 
 }

--- a/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzOutputToAllProtocol.java
+++ b/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzOutputToAllProtocol.java
@@ -42,8 +42,7 @@ import dk.alexandra.fresco.suite.spdz.evaluation.strategy.SpdzProtocolSuite;
 import dk.alexandra.fresco.suite.spdz.storage.SpdzStorage;
 import dk.alexandra.fresco.suite.spdz.utils.Util;
 
-public class SpdzOutputToAllProtocol extends SpdzNativeProtocol implements
-		OpenIntProtocol {
+public class SpdzOutputToAllProtocol extends SpdzNativeProtocol implements OpenIntProtocol {
 
 	private SpdzSInt in;
 	private SpdzOInt out;
@@ -54,10 +53,10 @@ public class SpdzOutputToAllProtocol extends SpdzNativeProtocol implements
 	}
 
 	@Override
-	public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
-			SCENetwork network) {
-		SpdzProtocolSuite spdzpii = SpdzProtocolSuite
-				.getInstance(resourcePool.getMyId());
+	public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {		
+		SpdzProtocolSuite spdzpii = SpdzProtocolSuite.getInstance(resourcePool.getMyId());
+		spdzpii.outputProtocolUsedInBatch();
+		
 		SpdzStorage storage = spdzpii.getStore(network.getThreadId());
 		switch (round) {
 		case 0:
@@ -74,7 +73,7 @@ public class SpdzOutputToAllProtocol extends SpdzNativeProtocol implements
 			storage.addOpenedValue(openedVal);
 			storage.addClosedValue(in.value);
 			BigInteger tmpOut = openedVal;
-			//tmpOut = Util.convertRepresentation(tmpOut);
+			// tmpOut = Util.convertRepresentation(tmpOut);
 			out.setValue(tmpOut);
 			return EvaluationStatus.IS_DONE;
 		default:


### PR DESCRIPTION
MacChecks are now done after each batch if an outputgate is amongst the batch. This mitigates the attack vector previously exposed where an attacker could learn something about the other parties input after an opening - e.g. a branching depending on the output.