### PR TITLE
Revert "Fixes a crash bug caused by an incorrect cast."

### DIFF
--- a/src/main/java/dk/alexandra/fresco/framework/network/ScapiNetworkImpl.java
+++ b/src/main/java/dk/alexandra/fresco/framework/network/ScapiNetworkImpl.java
@@ -154,7 +154,7 @@ public class ScapiNetworkImpl implements Network {
 					PartyData pd = idToPartyData.get(partyId);
 					Map<String, Channel> channels = connections.get(pd);
 					String cStr = "" + i;
-					Channel c = channels.get(cStr);
+					PlainChannel c = (PlainChannel)channels.get(cStr);
 					Channel secureChannel;
 					String sharedSecretKey = sharedSecretKeys.get(id); 
 					try {
@@ -185,7 +185,7 @@ public class ScapiNetworkImpl implements Network {
 		return authedChannel;
 	}
 
-	private EncryptedChannel getSecureChannel(Channel c, String base64EncodedSSKey) throws InvalidKeyException, SecurityLevelException {
+	private EncryptedChannel getSecureChannel(PlainChannel ch, String base64EncodedSSKey) throws InvalidKeyException, SecurityLevelException {
 		byte[] aesFixedKey = Base64.decodeFromString(base64EncodedSSKey);
 		SecretKey aesKey = new SecretKeySpec(aesFixedKey, "AES");
 		AES encryptAes = new BcAES();
@@ -195,7 +195,7 @@ public class ScapiNetworkImpl implements Network {
 		macAes.setKey(aesKey);
 		ScCbcMacPrepending cbcMac = new ScCbcMacPrepending(macAes);
 		ScEncryptThenMac encThenMac = new ScEncryptThenMac(enc, cbcMac);
-		EncryptedChannel secureChannel = new EncryptedChannel(c, encThenMac);
+		EncryptedChannel secureChannel = new EncryptedChannel(ch, encThenMac);
 		return secureChannel;
 	}
 	


### PR DESCRIPTION
Reverts aicis/fresco#31
Does not compile with the version of SCAPI that FRESCO uses.