### PR TITLE
Dummy arithmetic protocol suite

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/framework/network/KryoNetNetwork.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/network/KryoNetNetwork.java
@@ -265,7 +265,7 @@ public class KryoNetNetwork implements Network {
 					this.clients.get(i).get(j).stop();
 				}
 			}
-		}
+		}	
 	}
 	
 	private static class Registrator {

--- a/core/src/main/java/dk/alexandra/fresco/framework/network/KryoNetNetwork.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/network/KryoNetNetwork.java
@@ -254,7 +254,8 @@ public class KryoNetNetwork implements Network {
 
 	@Override
 	public void close() throws IOException {		
-		Reporter.fine("Shutting down KryoNet network");
+		Reporter.fine("Shutting down KryoNet network");		
+		
 		for(int j = 0; j < channelAmount; j++) {
 			this.servers.get(j).stop();			
 		}
@@ -266,6 +267,7 @@ public class KryoNetNetwork implements Network {
 				}
 			}
 		}	
+		
 	}
 	
 	private static class Registrator {

--- a/core/src/main/java/dk/alexandra/fresco/framework/network/Network.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/network/Network.java
@@ -3,26 +3,23 @@
  *
  * This file is part of the FRESCO project.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
- * and Bouncy Castle. Please see these projects for any further licensing issues.
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL, and Bouncy Castle.
+ * Please see these projects for any further licensing issues.
  *******************************************************************************/
 package dk.alexandra.fresco.framework.network;
 
@@ -36,58 +33,52 @@ import dk.alexandra.fresco.framework.configuration.NetworkConfiguration;
  */
 public interface Network {
 
-	/**
-	 * Initializes the network using the given {@code conf} and prepares
-	 * {@code channelAmount} channels towards each party. This method does not
-	 * actually connect any parties to each other. For that, call
-	 * {@link #connect(int)}.
-	 * 
-	 * @param conf
-	 *            The network configuration to use.
-	 * @param channelAmount
-	 *            The amount of channels towards each party.
-	 */
-	void init(NetworkConfiguration conf, int channelAmount);
+  /**
+   * Initializes the network using the given {@code conf} and prepares {@code channelAmount}
+   * channels towards each party. This method does not actually connect any parties to each other.
+   * For that, call {@link #connect(int)}.
+   * 
+   * @param conf The network configuration to use.
+   * @param channelAmount The amount of channels towards each party.
+   */
+  void init(NetworkConfiguration conf, int channelAmount);
 
-	/**
-	 * Attempts to connect with other players.
-	 * 
-	 * Blocks until connection is successful.
-	 * 
-	 * @param timeoutMillis
-	 *            The amount of milliseconds before an IOException is thrown in
-	 *            case of connection failure.
-	 */
-	void connect(int timeoutMillis) throws IOException;
+  /**
+   * Attempts to connect with other players.
+   * 
+   * Blocks until connection is successful.
+   * 
+   * @param timeoutMillis The amount of milliseconds before an IOException is thrown in case of
+   *        connection failure.
+   */
+  void connect(int timeoutMillis) throws IOException;
 
-	/**
-	 * Send data to other party with id partyId. This network will automatically
-	 * figure out the size on the receiving end.
-	 * 
-	 * @param channelId
-	 *            the channel to send data over.
-	 * @param partyId
-	 *            the party to send data to
-	 * @param data
-	 *            the data to send
-	 * @throws IOException
-	 *             thrown if the connection has problems.
-	 */
-	void send(int channelId, int partyId, byte[] data) throws IOException;
+  /**
+   * Send data to other party with id partyId. This network will automatically figure out the size
+   * on the receiving end.
+   * 
+   * @param channelId the channel to send data over.
+   * @param partyId the party to send data to
+   * @param data the data to send
+   * @throws IOException thrown if the connection has problems.
+   */
+  void send(int channelId, int partyId, byte[] data) throws IOException;
 
-	/**
-	 * Blocking call that only returns once the data has been fully received and
-	 * deserialized.
-	 * 
-	 * @param channelId
-	 *            the channel to receive from
-	 * @param partyId
-	 *            the party to receive from
-	 * @return the data send by the given partyId through the given channel
-	 * @throws IOException
-	 *             if the channel times out or other connection issues occurs.
-	 */
-	byte[] receive(int channelId, int partyId) throws IOException;
+  /**
+   * Blocking call that only returns once the data has been fully received and deserialized.
+   * 
+   * @param channelId the channel to receive from
+   * @param partyId the party to receive from
+   * @return the data send by the given partyId through the given channel
+   * @throws IOException if the channel times out or other connection issues occurs.
+   */
+  byte[] receive(int channelId, int partyId) throws IOException;
 
-	public void close() throws IOException;
+  /**
+   * Shuts down the network - when returning from this method it is expected that the ports used are
+   * accesible again.
+   * 
+   * @throws IOException If the connection could not be shut down.
+   */
+  public void close() throws IOException;
 }

--- a/core/src/main/java/dk/alexandra/fresco/framework/sce/SecureComputationEngineImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/sce/SecureComputationEngineImpl.java
@@ -36,6 +36,7 @@ import dk.alexandra.fresco.framework.Reporter;
 import dk.alexandra.fresco.framework.configuration.ConfigurationException;
 import dk.alexandra.fresco.framework.configuration.NetworkConfiguration;
 import dk.alexandra.fresco.framework.configuration.NetworkConfigurationImpl;
+import dk.alexandra.fresco.framework.network.KryoNetNetwork;
 import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.network.NetworkingStrategy;
 import dk.alexandra.fresco.framework.network.ScapiNetworkImpl;
@@ -104,8 +105,8 @@ public class SecureComputationEngineImpl implements SecureComputationEngine {
       case KRYONET:
         // TODO[PSN]
         // This might work on mac?
-//          network = new KryoNetNetwork();
-        network = new ScapiNetworkImpl();
+        network = new KryoNetNetwork();
+        //network = new ScapiNetworkImpl();
         break;
       case SCAPI:
         network = new ScapiNetworkImpl();

--- a/core/src/main/java/dk/alexandra/fresco/framework/sce/SecureComputationEngineImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/sce/SecureComputationEngineImpl.java
@@ -43,12 +43,9 @@ import dk.alexandra.fresco.framework.network.ScapiNetworkImpl;
 import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
 import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
-import dk.alexandra.fresco.framework.sce.resources.storage.StreamedStorage;
 import dk.alexandra.fresco.suite.ProtocolSuite;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -88,53 +85,6 @@ public class SecureComputationEngineImpl implements SecureComputationEngine {
 
     this.evaluator = this.sceConf.getEvaluator();
     this.evaluator.setMaxBatchSize(sceConf.getMaxBatchSize());
-
-  }
-
-  private static Network getNetworkFromConfiguration(SCEConfiguration sceConf,
-      int myId, Map<Integer, Party> parties) {
-    int channelAmount = 1;
-    NetworkConfiguration conf = new NetworkConfigurationImpl(myId, parties);
-    return buildNetwork(conf, channelAmount, sceConf.getNetworkStrategy());
-  }
-
-  private static Network buildNetwork(NetworkConfiguration conf,
-      int channelAmount, NetworkingStrategy networkStrat) {
-    Network network;
-    switch (networkStrat) {
-      case KRYONET:
-        // TODO[PSN]
-        // This might work on mac?
-        network = new KryoNetNetwork();
-        //network = new ScapiNetworkImpl();
-        break;
-      case SCAPI:
-        network = new ScapiNetworkImpl();
-        break;
-      default:
-        throw new ConfigurationException("Unknown networking strategy " + networkStrat);
-    }
-    network.init(conf, channelAmount);
-    return network;
-  }
-
-  public static ResourcePoolImpl createResourcePool(SCEConfiguration sceConf) throws IOException {
-    int myId = sceConf.getMyId();
-    Map<Integer, Party> parties = sceConf.getParties();
-
-    StreamedStorage streamedStorage = sceConf.getStreamedStorage();
-    // Secure random by default.
-    Random rand = new Random(0);
-    SecureRandom secRand = new SecureRandom();
-
-    Network network = getNetworkFromConfiguration(sceConf, myId, parties);
-    network.connect(10000);
-
-    ResourcePoolImpl resourcePool =
-        new ResourcePoolImpl(myId, parties.size(),
-            network, streamedStorage, rand, secRand);
-
-    return resourcePool;
 
   }
 

--- a/core/src/main/java/dk/alexandra/fresco/lib/compare/gt/GreaterThanReducerProtocolImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/compare/gt/GreaterThanReducerProtocolImpl.java
@@ -132,7 +132,7 @@ public class GreaterThanReducerProtocolImpl implements GreaterThanProtocol {
   private SInt mPrime, rPrime;
 
   @Override
-  public void getNextProtocols(ProtocolCollection protocolCollection) {
+  public void getNextProtocols(ProtocolCollection protocolCollection) {    
     if (pp == null) {
       switch (round) {
         case 0:

--- a/core/src/main/java/dk/alexandra/fresco/lib/math/integer/exp/PreprocessedExpPipeFactory.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/math/integer/exp/PreprocessedExpPipeFactory.java
@@ -30,5 +30,10 @@ import dk.alexandra.fresco.framework.value.SInt;
 
 public interface PreprocessedExpPipeFactory {
 
-	public SInt[] getExponentiationPipe();
+  /**
+   * Creates an array containing the list of r^-1, r, r^2, ... r^{max bit size}
+   * The maximum bit size is defined by the implementing factory. 
+   * @return An array of r^-1, r, r^2, ... r^{max bit size}
+   */
+  public SInt[] getExponentiationPipe();
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticAddProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticAddProtocol.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
+
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.OInt;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.AddProtocol;
+
+public class DummyArithmeticAddProtocol extends DummyArithmeticProtocol implements AddProtocol{
+
+  private DummyArithmeticSInt left, right, out;
+  private DummyArithmeticOInt open;
+  
+  public DummyArithmeticAddProtocol(SInt left, SInt right, SInt out) {
+    super();
+    this.left = (DummyArithmeticSInt)left;
+    this.right = (DummyArithmeticSInt)right;
+    this.out = (DummyArithmeticSInt)out;
+  }
+  
+  public DummyArithmeticAddProtocol(SInt left, OInt right, SInt out) {
+    super();
+    this.left = (DummyArithmeticSInt)left;
+    this.open = (DummyArithmeticOInt)right;
+    this.out = (DummyArithmeticSInt)out;
+  }
+
+  @Override
+  public Object getOutputValues() {
+    return out;
+  }
+
+  @Override
+  public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+    BigInteger mod = DummyArithmeticProtocolSuite.getModulus();
+    if(right != null) {
+      this.out.setValue(left.getValue().add(right.getValue()).mod(mod));
+    } else {
+      this.out.setValue(left.getValue().add(open.getValue()).mod(mod));
+    }
+    return EvaluationStatus.IS_DONE;
+  }
+
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticCloseProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticCloseProtocol.java
@@ -1,0 +1,73 @@
+
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
+
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.network.serializers.BigIntegerSerializer;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.OInt;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.CloseIntProtocol;
+
+public class DummyArithmeticCloseProtocol extends DummyArithmeticProtocol implements CloseIntProtocol{
+
+  private int targetId;
+  private DummyArithmeticOInt open;
+  private DummyArithmeticSInt closed;
+  
+  public DummyArithmeticCloseProtocol(int targetId, OInt open, SInt closed) {
+    super();
+    this.targetId = targetId;
+    this.open = (DummyArithmeticOInt) open;
+    this.closed = (DummyArithmeticSInt) closed;
+  }
+
+  @Override
+  public Object getOutputValues() {    
+    return closed;
+  }
+
+  @Override
+  public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+    if(round == 0) {
+      if(targetId == resourcePool.getMyId()) {
+        network.sendToAll(BigIntegerSerializer.toBytes(open.getValue()));
+      }
+      network.expectInputFromPlayer(targetId);
+      return EvaluationStatus.HAS_MORE_ROUNDS;
+    } else {
+      BigInteger b = BigIntegerSerializer.toBigInteger(network.receive(targetId));
+      this.closed.setValue(b);
+      return EvaluationStatus.IS_DONE;
+    }
+    
+  }
+
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticFactory.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticFactory.java
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+import dk.alexandra.fresco.framework.ProtocolProducer;
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.KnownSIntProtocol;
+import dk.alexandra.fresco.framework.value.OInt;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.AddProtocol;
+import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
+import dk.alexandra.fresco.lib.field.integer.CloseIntProtocol;
+import dk.alexandra.fresco.lib.field.integer.MultProtocol;
+import dk.alexandra.fresco.lib.field.integer.OpenIntProtocol;
+import dk.alexandra.fresco.lib.field.integer.RandomFieldElementProtocol;
+import dk.alexandra.fresco.lib.field.integer.SubtractProtocol;
+import dk.alexandra.fresco.lib.helper.SimpleProtocolProducer;
+import dk.alexandra.fresco.lib.helper.sequential.SequentialProtocolProducer;
+import dk.alexandra.fresco.lib.math.integer.exp.ExpFromOIntFactory;
+import dk.alexandra.fresco.lib.math.integer.exp.PreprocessedExpPipeFactory;
+import dk.alexandra.fresco.lib.math.integer.inv.LocalInversionFactory;
+import dk.alexandra.fresco.lib.math.integer.inv.LocalInversionProtocol;
+
+public class DummyArithmeticFactory implements BasicNumericFactory, LocalInversionFactory, ExpFromOIntFactory, PreprocessedExpPipeFactory{
+
+  private BigInteger mod;
+  private int maxBitLength;
+  
+  public DummyArithmeticFactory(BigInteger mod, int maxBitLength) {
+    this.mod = mod;
+    this.maxBitLength = maxBitLength;
+  }
+  
+  @Override
+  public SInt getSInt() {
+    return new DummyArithmeticSInt();
+  }
+
+  @Override
+  public SInt getSInt(int i) {
+    return new DummyArithmeticSInt(i);
+  }
+
+  @Override
+  public SInt getSInt(BigInteger i) {
+    return new DummyArithmeticSInt(i);
+  }
+
+  @Override
+  public KnownSIntProtocol getSInt(int i, SInt si) {
+    return getSInt(BigInteger.valueOf(i), si);
+  }
+
+  @Override
+  public KnownSIntProtocol getSInt(BigInteger i, SInt si) {
+    return new KnownSIntProtocol() {
+
+      @Override
+      public Object getOutputValues() {
+        return si;
+      }
+
+      @Override
+      public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+        DummyArithmeticSInt x = (DummyArithmeticSInt) si;
+        x.setValue(i);
+        return EvaluationStatus.IS_DONE;
+      }
+    };
+  }
+
+  @Override
+  public OInt getOInt() {
+    return new DummyArithmeticOInt();
+  }
+
+  @Override
+  public OInt getOInt(BigInteger i) {
+    return new DummyArithmeticOInt(i);
+  }
+
+  @Override
+  public OInt getRandomOInt() {
+    Random rand = new Random(42);
+    return new DummyArithmeticOInt(new BigInteger(23, rand).mod(mod));
+  }
+
+  @Override
+  public AddProtocol getAddProtocol(SInt a, SInt b, SInt out) {
+    return new DummyArithmeticAddProtocol(a, b, out);
+  }
+
+  @Override
+  public AddProtocol getAddProtocol(SInt input, OInt openInput, SInt out) {
+    return new DummyArithmeticAddProtocol(input, openInput, out);
+  }
+
+  @Override
+  public SubtractProtocol getSubtractProtocol(SInt a, SInt b, SInt out) {
+    return new DummyArithmeticSubtractProtocol(a, b, out);
+  }
+
+  @Override
+  public SubtractProtocol getSubtractProtocol(OInt a, SInt b, SInt out) {
+    return new DummyArithmeticSubtractProtocol(a, b, out);
+  }
+
+  @Override
+  public SubtractProtocol getSubtractProtocol(SInt a, OInt b, SInt out) {
+    return new DummyArithmeticSubtractProtocol(a, b, out);
+  }
+
+  @Override
+  public MultProtocol getMultProtocol(SInt a, SInt b, SInt out) {
+    return new DummyArithmeticMultProtocol(a, b, out);
+  }
+
+  @Override
+  public MultProtocol getMultProtocol(OInt a, SInt b, SInt c) {
+    return new DummyArithmeticMultProtocol(b, a, c);
+  }
+
+  @Override
+  public CloseIntProtocol getCloseProtocol(BigInteger open, SInt closed, int targetID) {
+    return new DummyArithmeticCloseProtocol(targetID, getOInt(open), closed);
+  }
+
+  @Override
+  public CloseIntProtocol getCloseProtocol(int source, OInt open, SInt closed) {
+    return new DummyArithmeticCloseProtocol(source, open, closed);
+  }
+
+  @Override
+  public OpenIntProtocol getOpenProtocol(SInt closed, OInt open) {
+    return new OpenIntProtocol() {
+      
+      @Override
+      public Object getOutputValues() {
+        return open;
+      }
+      
+      @Override
+      public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+        open.setSerializableContent(closed.getSerializableContent());
+        return EvaluationStatus.IS_DONE;
+      }
+    };
+  }
+
+  @Override
+  public OpenIntProtocol getOpenProtocol(int target, SInt closed, OInt open) {
+    return new OpenIntProtocol() {
+      
+      @Override
+      public Object getOutputValues() {
+        return open;
+      }
+      
+      @Override
+      public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+        if(resourcePool.getMyId() == target) {
+          open.setSerializableContent(closed.getSerializableContent());
+        }
+        return EvaluationStatus.IS_DONE;
+      }
+    };
+  }
+
+  @Override
+  public ProtocolProducer createRandomSecretSharedBitProtocol(SInt bit) {
+    return new SimpleProtocolProducer() {
+      
+      @Override
+      protected ProtocolProducer initializeProtocolProducer() {
+        DummyArithmeticSInt x = (DummyArithmeticSInt)bit;
+        x.setValue(BigInteger.valueOf(1));
+        return new SequentialProtocolProducer();
+      }
+    };
+  }
+
+  @Override
+  public RandomFieldElementProtocol getRandomFieldElement(SInt randomElement) {
+    return new RandomFieldElementProtocol() {
+      
+      @Override
+      public Object getOutputValues() {
+        return randomElement;
+      }
+      
+      @Override
+      public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+        DummyArithmeticSInt x = (DummyArithmeticSInt)randomElement;
+        x.setValue(new BigInteger(100, new Random(42)).mod(mod));
+        return EvaluationStatus.IS_DONE;
+      }
+    };
+  }
+
+  @Override
+  public int getMaxBitLength() {
+    return maxBitLength;
+  }
+
+  @Override
+  public SInt getSqrtOfMaxValue() {
+    BigInteger two = BigInteger.valueOf(2);
+    BigInteger max = mod.subtract(BigInteger.ONE).divide(two);
+    int bitlength = max.bitLength();
+    BigInteger approxMaxSqrt = two.pow(bitlength / 2);
+    return getSInt(approxMaxSqrt);
+  }
+
+  @Override
+  public BigInteger getModulus() {
+    return mod;
+  }
+
+  @Override
+  public LocalInversionProtocol getLocalInversionProtocol(OInt x, OInt result) {
+    return new LocalInversionProtocol() {
+      
+      @Override
+      public Object getOutputValues() {
+        return result;
+      }
+      
+      @Override
+      public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+        result.setValue(x.getValue().modInverse(mod));
+        return EvaluationStatus.IS_DONE;
+      }
+    };
+  }
+
+  @Override
+  public OInt[] getExpFromOInt(OInt value, int maxExp) {
+    BigInteger[] Ms = new BigInteger[maxExp];
+    Ms[0] = value.getValue();
+    for(int i = 1; i < Ms.length; i++){
+        Ms[i] = Ms[i-1].multiply(value.getValue()).mod(mod);
+    }
+    OInt[] expPipe = new OInt[Ms.length];
+    for (int i = 0; i < Ms.length; i++) {
+      expPipe[i] = new DummyArithmeticOInt(Ms[i]);
+    }
+    return expPipe;
+  }
+
+  @Override
+  public SInt[] getExponentiationPipe() {    
+    BigInteger value = BigInteger.valueOf(1);
+    BigInteger[] Ms = new BigInteger[maxBitLength+1];
+    Ms[0] = value.modInverse(mod);
+    Ms[1] = value;
+    for(int i = 2; i < Ms.length; i++){
+        Ms[i] = Ms[i-1].multiply(value).mod(mod);
+    }
+    SInt[] expPipe = new SInt[Ms.length];
+    for (int i = 0; i < Ms.length; i++) {
+      expPipe[i] = new DummyArithmeticSInt(Ms[i]);
+    }
+    return expPipe;
+  }
+
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticMultProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticMultProtocol.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
  *
  * This file is part of the FRESCO project.
  *
@@ -24,61 +24,51 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
 
 import dk.alexandra.fresco.framework.network.SCENetwork;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
-import dk.alexandra.fresco.framework.value.OBool;
-import dk.alexandra.fresco.framework.value.SBool;
-import dk.alexandra.fresco.framework.value.Value;
-import dk.alexandra.fresco.lib.field.bool.OpenBoolProtocol;
+import dk.alexandra.fresco.framework.value.OInt;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.MultProtocol;
 
-public class DummyOpenBoolProtocol extends DummyProtocol implements OpenBoolProtocol {
+public class DummyArithmeticMultProtocol extends DummyArithmeticProtocol implements MultProtocol{
 
-	public DummySBool input;
-	public DummyOBool output;
-	
-	private int target;
-	
-	/**
-	 * Opens to all.
-	 * 
-	 */
-	public DummyOpenBoolProtocol(SBool in, OBool out) {
-		input = (DummySBool)in;
-		output = (DummyOBool)out;
-		target = -1; // open to all
-	}
-	
-	/**
-	 * Opens to player with targetId.
-	 * 
-	 */
-	public DummyOpenBoolProtocol(SBool in, OBool out, int targetId) {
-		input = (DummySBool)in;
-		output = (DummyOBool)out;
-		target = targetId;
-	}
-	
-	@Override
-	public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
-			SCENetwork network) {
-		boolean openToAll = target == -1;
-		if (resourcePool.getMyId() == target || openToAll) {
-			this.output.setValue(this.input.getValue());
-		}
-		return EvaluationStatus.IS_DONE;
-	}	
-	
-	@Override
-	public String toString() {
-		return "DummyOpenBoolGate(" + input + "," + output + ")";
-	}
+  private DummyArithmeticSInt left, right, out;
+  private DummyArithmeticOInt open;
+  
+  public DummyArithmeticMultProtocol(SInt left, SInt right,
+      SInt out) {
+    super();
+    this.left = (DummyArithmeticSInt)left;
+    this.right = (DummyArithmeticSInt)right;
+    this.out = (DummyArithmeticSInt)out;
+  }
+  
+  public DummyArithmeticMultProtocol(SInt left, OInt right,
+      SInt out) {
+    super();
+    this.left = (DummyArithmeticSInt)left;
+    this.open = (DummyArithmeticOInt)right;
+    this.out = (DummyArithmeticSInt)out;
+  }
 
-	@Override
-	public Value[] getOutputValues() {
-		return new Value[] {this.output};
-	}
+  @Override
+  public Object getOutputValues() {
+    return out;
+  }
 
-	
+  @Override
+  public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {    
+    BigInteger mod = DummyArithmeticProtocolSuite.getModulus();
+    if(right != null) {
+      this.out.setValue(left.getValue().multiply(right.getValue()).mod(mod));
+    } else {
+      this.out.setValue(left.getValue().multiply(open.getValue()).mod(mod));
+    }
+    return EvaluationStatus.IS_DONE;
+  }
+
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticOInt.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticOInt.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
  *
  * This file is part of the FRESCO project.
  *
@@ -24,67 +24,30 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.arithmetic;
 
-import dk.alexandra.fresco.framework.value.SBool;
+import java.math.BigInteger;
 
+import dk.alexandra.fresco.framework.value.GenericOInt;
 
-public class DummySBool implements SBool {
+public class DummyArithmeticOInt extends GenericOInt {
 
-	private static final long serialVersionUID = -4614951451129474002L;
-	
-	private final String id;
-	
-	private Boolean value;
-	
-	public DummySBool(String id) {
-		this.value = null;
-		this.id = id;
-	}
-	
-	public DummySBool(String id, boolean b) {
-		this.value = b;
-		this.id = id;
-	}
+  public DummyArithmeticOInt() {
+    super();
+  }
+  
+  public DummyArithmeticOInt(BigInteger value) {
+    super(value);
+  }
+  
+  @Override
+  public String toString() {
+    return "DummyArithmeticOInt ["+getValue()+"]";
+  }
 
-	@Override
-	public byte[] getSerializableContent() {
-		byte s;
-		if (this.value) { 
-			s = 1;
-		} else {
-			s = 0;
-		}
-		return new byte[] {s};
-	}
+  /**
+   * 
+   */
+  private static final long serialVersionUID = 816964176655769428L;
 
-	@Override
-	public void setSerializableContent(byte[] val) {
-		this.value = val[0] == 1;
-	}
-
-	@Override
-	public boolean isReady() {
-		return this.value != null;
-	}
-
-	public boolean getValue() {
-		return this.value;
-	}
-
-	public void setValue(boolean val) {
-		this.value = val;
-	}
-	
-
-	@Override
-	public String toString() {
-		if (this.value != null) {
-			return "DummySBool(" + this.id + "; " + this.value + ")";
-		} else {
-			return "DummySBool(" + this.id + "; null)";
-		}
-	}
-	
-	
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticProtocol.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import dk.alexandra.fresco.framework.NativeProtocol;
+
+public abstract class DummyArithmeticProtocol implements NativeProtocol {
+
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticProtocolSuite.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticProtocolSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
  *
  * This file is part of the FRESCO project.
  *
@@ -24,41 +24,66 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.arithmetic;
 
+import java.math.BigInteger;
+
+import dk.alexandra.fresco.framework.MPCException;
+import dk.alexandra.fresco.framework.ProtocolFactory;
 import dk.alexandra.fresco.framework.network.SCENetwork;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.suite.ProtocolSuite;
+import dk.alexandra.fresco.suite.dummy.arithmetic.config.DummyArithmeticConfiguration;
 
+public class DummyArithmeticProtocolSuite implements ProtocolSuite {
 
-/**
- * Dummy protocol suite that does no secret computation. Only for testing purposes.
- *
- * Do NOT use in production! :-)
- *
- * Currently it only implements basic logic operations "natively".
- */
-public class DummyProtocolSuite implements ProtocolSuite {
-
+  private static BigInteger modulus;
+  private static int maxBitLength;
+  
+  public DummyArithmeticProtocolSuite(DummyArithmeticConfiguration conf) {
+    DummyArithmeticProtocolSuite.modulus = conf.getModulus();
+    DummyArithmeticProtocolSuite.maxBitLength = conf.getMaxBitLength();
+  }
+  
+  public static BigInteger getModulus() {
+    return modulus;
+  }
+  
+  public static int getMaxBitLength() {
+    return maxBitLength;
+  }
+  
   @Override
-  public DummyFactory init(ResourcePool resourcePool) {
-    return new DummyFactory();
+  public ProtocolFactory init(ResourcePool resourcePool) {
+    return new DummyArithmeticFactory(modulus, maxBitLength);
   }
 
   @Override
   public RoundSynchronization createRoundSynchronization() {
-    return new DummyRoundSynchronization();
+    return new RoundSynchronization() {
+      
+      @Override
+      public boolean roundFinished(int round, ResourcePool resourcePool, SCENetwork network)
+          throws MPCException {
+        // TODO Auto-generated method stub
+        return false;
+      }
+      
+      @Override
+      public void finishedBatch(int gatesEvaluated, ResourcePool resourcePool, SCENetwork sceNetwork)
+          throws MPCException {
+        // TODO Auto-generated method stub
+        
+      }
+    };
   }
 
   @Override
   public void finishedEval(ResourcePool resourcePool, SCENetwork sceNetwork) {
-    // No finish needed.
   }
 
   @Override
-  public void destroy() {
-    // No destroy needed.
+  public void destroy() {    
   }
-
 
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticSInt.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticSInt.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
+
+import dk.alexandra.fresco.framework.value.SInt;
+
+public class DummyArithmeticSInt implements SInt {
+
+  private static final long serialVersionUID = 5434286774741799773L;
+  private BigInteger value;
+  
+  public DummyArithmeticSInt() {
+    
+  }
+  
+  public DummyArithmeticSInt(BigInteger value) {
+    this.value = value;
+  }
+  
+  public DummyArithmeticSInt(int value) {
+    this.value = BigInteger.valueOf(value);
+  }
+  
+  public BigInteger getValue() {
+    return value;
+  }
+  
+  public void setValue(BigInteger value) {
+    this.value = value;
+  }
+  
+  @Override
+  public byte[] getSerializableContent() {
+    return this.value.toByteArray();
+  }
+
+  @Override
+  public void setSerializableContent(byte[] val) {
+    this.value = new BigInteger(val);
+  }
+
+  @Override
+  public boolean isReady() {
+    return this.value != null;
+  }
+
+  @Override
+  public String toString() {
+    return "DummyArithmeticSInt [value=" + value + "]";
+  }
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticSubtractProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticSubtractProtocol.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
+
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.OInt;
+import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.SubtractProtocol;
+
+public class DummyArithmeticSubtractProtocol extends DummyArithmeticProtocol implements SubtractProtocol{
+
+  private DummyArithmeticSInt left, right, out;
+  private DummyArithmeticOInt openLeft, openRight;
+  
+  public DummyArithmeticSubtractProtocol(SInt left, SInt right, SInt out) {
+    super();
+    this.left = (DummyArithmeticSInt)left;
+    this.right = (DummyArithmeticSInt)right;
+    this.out = (DummyArithmeticSInt)out;
+  }
+  
+  public DummyArithmeticSubtractProtocol(SInt left, OInt right, SInt out) {
+    super();
+    this.left = (DummyArithmeticSInt)left;
+    this.openRight = (DummyArithmeticOInt)right;
+    this.out = (DummyArithmeticSInt)out;
+  }
+
+  public DummyArithmeticSubtractProtocol(OInt a, SInt b, SInt out) {
+    super();
+    this.openLeft = (DummyArithmeticOInt)a;
+    this.right = (DummyArithmeticSInt)b;    
+    this.out = (DummyArithmeticSInt)out;
+  }
+
+  @Override
+  public Object getOutputValues() {
+    return out;
+  }
+
+  @Override
+  public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
+    BigInteger mod = DummyArithmeticProtocolSuite.getModulus();
+    if(left != null && right != null) {
+      this.out.setValue(left.getValue().subtract(right.getValue()).mod(mod));
+    } else if(left != null && openRight != null){
+      this.out.setValue(left.getValue().subtract(openRight.getValue()).mod(mod));
+    } else {
+      this.out.setValue(openLeft.getValue().subtract(right.getValue()).mod(mod));
+    }
+    return EvaluationStatus.IS_DONE;
+  }
+
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticSubtractProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticSubtractProtocol.java
@@ -68,6 +68,7 @@ public class DummyArithmeticSubtractProtocol extends DummyArithmeticProtocol imp
   @Override
   public EvaluationStatus evaluate(int round, ResourcePool resourcePool, SCENetwork network) {
     BigInteger mod = DummyArithmeticProtocolSuite.getModulus();
+    
     if(left != null && right != null) {
       this.out.setValue(left.getValue().subtract(right.getValue()).mod(mod));
     } else if(left != null && openRight != null){
@@ -75,6 +76,7 @@ public class DummyArithmeticSubtractProtocol extends DummyArithmeticProtocol imp
     } else {
       this.out.setValue(openLeft.getValue().subtract(right.getValue()).mod(mod));
     }
+    //System.out.println("left: " + left+", right: "+ right+", out: " + out +", openLeft: " + openLeft+", openRight: "+ openRight+", out: " + out);
     return EvaluationStatus.IS_DONE;
   }
 

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/config/DummyArithmeticConfiguration.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/config/DummyArithmeticConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
  *
  * This file is part of the FRESCO project.
  *
@@ -24,11 +24,28 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.arithmetic.config;
 
-import dk.alexandra.fresco.framework.NativeProtocol;
+import java.math.BigInteger;
 
-public abstract class DummyProtocol implements NativeProtocol {
+import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
 
-
+public interface DummyArithmeticConfiguration extends ProtocolSuiteConfiguration {
+  
+  /**
+   * Gets an approximation of the maximum bit length of any number appearing
+   * in an application. This is used by certain protocols, e.g., to avoid overflow
+   * when working in a Z_p field.
+   * TODO: Consider factoring out of the configuration as this is really specific
+   * only to certain protocols.
+   *
+   * @return the expected maximum bit length of any number appearing in the application.
+   */
+  int getMaxBitLength();
+  
+  /**
+   * 
+   * @return The modulus of the group we are simulating
+   */
+  BigInteger getModulus();
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/config/DummyArithmeticConfigurationFromProperties.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/config/DummyArithmeticConfigurationFromProperties.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.util.Properties;
+
+import org.apache.commons.cli.CommandLine;
+
+import dk.alexandra.fresco.framework.MPCException;
+import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
+import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
+import dk.alexandra.fresco.framework.sce.util.Util;
+import dk.alexandra.fresco.suite.ProtocolSuite;
+import dk.alexandra.fresco.suite.dummy.arithmetic.DummyArithmeticProtocolSuite;
+
+public class DummyArithmeticConfigurationFromProperties implements DummyArithmeticConfiguration{
+
+  private BigInteger modulus;
+  private int maxBitLength;
+
+  public DummyArithmeticConfigurationFromProperties() {
+    Properties prop;
+    final String defaultPropertiesLocation = "properties/dummy/arithmetic/dummy.properties";
+    InputStream is;
+    try {
+      is = Util.getInputStream(defaultPropertiesLocation);        
+      prop = new Properties();        
+      prop.load(is);          
+      
+      //default to a 512 bit mod - large enough for all tests to pass.
+      String modString = prop.getProperty("modulus", "6703903964971298549787012499123814115273848577471136527425966013026501536706464354255445443244279389455058889493431223951165286470575994074291745908195329");
+      BigInteger mod = new BigInteger(modString);
+      int maxBitLength = Integer.parseInt(prop.getProperty("maxBitLength", "-1"));
+      this.modulus = mod;
+      if(maxBitLength == -1) {
+        maxBitLength = mod.bitLength()/2-1; //Default value which should avoid overflow. 
+      }
+      this.maxBitLength = maxBitLength;
+    } catch (IOException e) {
+      throw new MPCException("Could not locate the SPDZ properties file. ", e);
+    }
+  }
+
+  public static ProtocolSuiteConfiguration fromCmdLine(SCEConfiguration sceConf, CommandLine cmd) {
+    Properties p = cmd.getOptionProperties("D");
+    String modString = p.getProperty("modulus", "6703903964971298549787012499123814115273848577471136527425966013026501536706464354255445443244279389455058889493431223951165286470575994074291745908195329");
+    BigInteger mod = new BigInteger(modString);
+    int maxBitLength = Integer.parseInt(p.getProperty("maxBitLength", "-1"));
+    DummyArithmeticConfigurationFromProperties conf = new DummyArithmeticConfigurationFromProperties();
+    conf.modulus = mod;
+    if(maxBitLength == -1) {
+      maxBitLength = mod.bitLength()/2-1; //Default value which should avoid overflow. 
+    }
+    conf.maxBitLength = maxBitLength;
+    return conf;
+  }
+
+
+
+  @Override
+  public ProtocolSuite createProtocolSuite(int myPlayerId) {
+    return new DummyArithmeticProtocolSuite(this);
+  }
+
+  @Override
+  public int getMaxBitLength() {
+    return maxBitLength;
+  }
+
+  @Override
+  public BigInteger getModulus() {
+    return modulus;
+  }
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyAndProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyAndProtocol.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.bool;
+
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.SBool;
+
+
+public class DummyAndProtocol extends DummyProtocol {
+
+  private DummySBool inLeft;
+  private DummySBool inRight;
+  private DummySBool out;
+
+  public DummyAndProtocol(SBool inLeft, SBool inRight, SBool out) {
+    this.inLeft = (DummySBool) inLeft;
+    this.inRight = (DummySBool) inRight;
+    this.out = (DummySBool) out;
+  }
+
+  @Override
+  public String toString() {
+    return "DummyAndGate(" + inLeft + "," + inRight + "," + out + ")";
+  }
+
+  @Override
+  public SBool getOutputValues() {
+    return out;
+  }
+
+  @Override
+  public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
+      SCENetwork network) {
+    this.out.setValue(this.inLeft.getValue() & this.inRight.getValue());
+    return EvaluationStatus.IS_DONE;
+  }
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyCloseBoolProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyCloseBoolProtocol.java
@@ -24,7 +24,7 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
 import dk.alexandra.fresco.framework.MPCException;
 import dk.alexandra.fresco.framework.network.SCENetwork;

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyConfiguration.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyConfiguration.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.bool;
+
+import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
+import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
+import dk.alexandra.fresco.suite.ProtocolSuite;
+import org.apache.commons.cli.CommandLine;
+
+public class DummyConfiguration implements ProtocolSuiteConfiguration {
+
+	public static ProtocolSuiteConfiguration fromCmdLine(SCEConfiguration sceConf, CommandLine cmd) {
+		return new DummyConfiguration();
+	}
+
+  @Override
+  public ProtocolSuite createProtocolSuite(int myPlayerId) {
+    return new DummyProtocolSuite();
+  }
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyFactory.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyFactory.java
@@ -24,7 +24,7 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
 import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.value.OBool;

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyNotProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyNotProtocol.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.bool;
+
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.SBool;
+import dk.alexandra.fresco.framework.value.Value;
+import dk.alexandra.fresco.lib.field.bool.NotProtocol;
+
+public class DummyNotProtocol extends DummyProtocol implements NotProtocol {
+
+	public DummySBool input;
+	public DummySBool output;
+	
+	public DummyNotProtocol(SBool in, SBool out) {
+		input = (DummySBool)in;
+		output = (DummySBool)out;
+	}
+	
+	@Override
+	public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
+			SCENetwork network) {
+		this.output.setValue(!this.input.getValue());
+		return EvaluationStatus.IS_DONE;
+	}	
+	
+	@Override
+	public String toString() {
+		return "DummyNotGate(" + input + "," + output + ")";
+	}
+
+	@Override
+	public Value[] getOutputValues() {
+		return new Value[] {this.output};
+	}
+
+	
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyOBool.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyOBool.java
@@ -24,7 +24,7 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
 import dk.alexandra.fresco.framework.value.OBool;
 

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyOpenBoolProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyOpenBoolProtocol.java
@@ -24,34 +24,55 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
 import dk.alexandra.fresco.framework.network.SCENetwork;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.framework.value.OBool;
 import dk.alexandra.fresco.framework.value.SBool;
 import dk.alexandra.fresco.framework.value.Value;
-import dk.alexandra.fresco.lib.field.bool.NotProtocol;
+import dk.alexandra.fresco.lib.field.bool.OpenBoolProtocol;
 
-public class DummyNotProtocol extends DummyProtocol implements NotProtocol {
+public class DummyOpenBoolProtocol extends DummyProtocol implements OpenBoolProtocol {
 
 	public DummySBool input;
-	public DummySBool output;
+	public DummyOBool output;
 	
-	public DummyNotProtocol(SBool in, SBool out) {
+	private int target;
+	
+	/**
+	 * Opens to all.
+	 * 
+	 */
+	public DummyOpenBoolProtocol(SBool in, OBool out) {
 		input = (DummySBool)in;
-		output = (DummySBool)out;
+		output = (DummyOBool)out;
+		target = -1; // open to all
+	}
+	
+	/**
+	 * Opens to player with targetId.
+	 * 
+	 */
+	public DummyOpenBoolProtocol(SBool in, OBool out, int targetId) {
+		input = (DummySBool)in;
+		output = (DummyOBool)out;
+		target = targetId;
 	}
 	
 	@Override
 	public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
 			SCENetwork network) {
-		this.output.setValue(!this.input.getValue());
+		boolean openToAll = target == -1;
+		if (resourcePool.getMyId() == target || openToAll) {
+			this.output.setValue(this.input.getValue());
+		}
 		return EvaluationStatus.IS_DONE;
 	}	
 	
 	@Override
 	public String toString() {
-		return "DummyNotGate(" + input + "," + output + ")";
+		return "DummyOpenBoolGate(" + input + "," + output + ")";
 	}
 
 	@Override

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyProtocol.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 FRESCO (http://github.com/aicis/fresco).
+ * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
  *
  * This file is part of the FRESCO project.
  *
@@ -24,21 +24,11 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
-import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
-import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
-import dk.alexandra.fresco.suite.ProtocolSuite;
-import org.apache.commons.cli.CommandLine;
+import dk.alexandra.fresco.framework.NativeProtocol;
 
-public class DummyConfiguration implements ProtocolSuiteConfiguration {
+public abstract class DummyProtocol implements NativeProtocol {
 
-	public static ProtocolSuiteConfiguration fromCmdLine(SCEConfiguration sceConf, CommandLine cmd) {
-		return new DummyConfiguration();
-	}
 
-  @Override
-  public ProtocolSuite createProtocolSuite(int myPlayerId) {
-    return new DummyProtocolSuite();
-  }
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyProtocolSuite.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyProtocolSuite.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2015 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.bool;
+
+import dk.alexandra.fresco.framework.network.SCENetwork;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
+import dk.alexandra.fresco.suite.ProtocolSuite;
+
+
+/**
+ * Dummy protocol suite that does no secret computation. Only for testing purposes.
+ *
+ * Do NOT use in production! :-)
+ *
+ * Currently it only implements basic logic operations "natively".
+ */
+public class DummyProtocolSuite implements ProtocolSuite {
+
+  @Override
+  public DummyFactory init(ResourcePool resourcePool) {
+    return new DummyFactory();
+  }
+
+  @Override
+  public RoundSynchronization createRoundSynchronization() {
+    return new DummyRoundSynchronization();
+  }
+
+  @Override
+  public void finishedEval(ResourcePool resourcePool, SCENetwork sceNetwork) {
+    // No finish needed.
+  }
+
+  @Override
+  public void destroy() {
+    // No destroy needed.
+  }
+
+
+}

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummySBool.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummySBool.java
@@ -24,39 +24,67 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
-import dk.alexandra.fresco.framework.network.SCENetwork;
-import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.framework.value.SBool;
 
 
-public class DummyAndProtocol extends DummyProtocol {
+public class DummySBool implements SBool {
 
-  private DummySBool inLeft;
-  private DummySBool inRight;
-  private DummySBool out;
+	private static final long serialVersionUID = -4614951451129474002L;
+	
+	private final String id;
+	
+	private Boolean value;
+	
+	public DummySBool(String id) {
+		this.value = null;
+		this.id = id;
+	}
+	
+	public DummySBool(String id, boolean b) {
+		this.value = b;
+		this.id = id;
+	}
 
-  public DummyAndProtocol(SBool inLeft, SBool inRight, SBool out) {
-    this.inLeft = (DummySBool) inLeft;
-    this.inRight = (DummySBool) inRight;
-    this.out = (DummySBool) out;
-  }
+	@Override
+	public byte[] getSerializableContent() {
+		byte s;
+		if (this.value) { 
+			s = 1;
+		} else {
+			s = 0;
+		}
+		return new byte[] {s};
+	}
 
-  @Override
-  public String toString() {
-    return "DummyAndGate(" + inLeft + "," + inRight + "," + out + ")";
-  }
+	@Override
+	public void setSerializableContent(byte[] val) {
+		this.value = val[0] == 1;
+	}
 
-  @Override
-  public SBool getOutputValues() {
-    return out;
-  }
+	@Override
+	public boolean isReady() {
+		return this.value != null;
+	}
 
-  @Override
-  public EvaluationStatus evaluate(int round, ResourcePool resourcePool,
-      SCENetwork network) {
-    this.out.setValue(this.inLeft.getValue() & this.inRight.getValue());
-    return EvaluationStatus.IS_DONE;
-  }
+	public boolean getValue() {
+		return this.value;
+	}
+
+	public void setValue(boolean val) {
+		this.value = val;
+	}
+	
+
+	@Override
+	public String toString() {
+		if (this.value != null) {
+			return "DummySBool(" + this.id + "; " + this.value + ")";
+		} else {
+			return "DummySBool(" + this.id + "; null)";
+		}
+	}
+	
+	
 }

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyXorProtocol.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/bool/DummyXorProtocol.java
@@ -24,7 +24,7 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
 import dk.alexandra.fresco.framework.network.SCENetwork;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;

--- a/core/src/test/java/dk/alexandra/fresco/framework/TestThreadRunner.java
+++ b/core/src/test/java/dk/alexandra/fresco/framework/TestThreadRunner.java
@@ -30,10 +30,14 @@ import com.esotericsoftware.minlog.Log;
 import dk.alexandra.fresco.framework.configuration.NetworkConfiguration;
 import dk.alexandra.fresco.framework.configuration.TestConfiguration;
 import dk.alexandra.fresco.framework.network.KryoNetNetwork;
+import dk.alexandra.fresco.framework.network.Network;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.sce.SCEFactory;
 import dk.alexandra.fresco.framework.sce.SecureComputationEngine;
 import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguration;
 import dk.alexandra.fresco.framework.sce.configuration.TestSCEConfiguration;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -108,7 +112,15 @@ public class TestThreadRunner {
     private void runTearDown() {
       try {
         if (secureComputationEngine != null) {
-          secureComputationEngine.shutdownSCE();
+          //Shut down SCE resources - does not include the resource pool.
+          secureComputationEngine.shutdownSCE();    
+          //Shut down network in particular. All tests should use the NetworkCreator 
+          //in order for this to work, or manage the network themselves.
+          Map<Integer, ResourcePoolImpl> rps = NetworkCreator.getCurrentResourcePools();
+          for(int id: rps.keySet()) {
+            Network network = rps.get(id).getNetwork();
+            network.close();
+          }           
         }
         tearDown();
         finished = true;

--- a/core/src/test/java/dk/alexandra/fresco/framework/TestThreadRunner.java
+++ b/core/src/test/java/dk/alexandra/fresco/framework/TestThreadRunner.java
@@ -38,6 +38,7 @@ import dk.alexandra.fresco.framework.sce.configuration.ProtocolSuiteConfiguratio
 import dk.alexandra.fresco.framework.sce.configuration.TestSCEConfiguration;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -113,14 +114,7 @@ public class TestThreadRunner {
       try {
         if (secureComputationEngine != null) {
           //Shut down SCE resources - does not include the resource pool.
-          secureComputationEngine.shutdownSCE();    
-          //Shut down network in particular. All tests should use the NetworkCreator 
-          //in order for this to work, or manage the network themselves.
-          Map<Integer, ResourcePoolImpl> rps = NetworkCreator.getCurrentResourcePools();
-          for(int id: rps.keySet()) {
-            Network network = rps.get(id).getNetwork();
-            network.close();
-          }           
+          secureComputationEngine.shutdownSCE();              
         }
         tearDown();
         finished = true;
@@ -221,7 +215,7 @@ public class TestThreadRunner {
         t.join(MAX_WAIT_FOR_THREAD);
       } catch (InterruptedException e) {
         throw new TestFrameworkException("Test was interrupted");
-      }
+      } 
       if (!t.finished) {
         Reporter.severe("" + t + " timed out");
         throw new TestFrameworkException(t + " timed out");
@@ -234,6 +228,26 @@ public class TestThreadRunner {
       } else if (t.teardownException != null) {
         throw new TestFrameworkException(t + " threw exception in teardown (see stderr)");
       }
+    }
+
+    //Cleanup - shut down network in manually. All tests should use the NetworkCreator 
+    //in order for this to work, or manage the network themselves.
+    Map<Integer, ResourcePoolImpl> rps = NetworkCreator.getCurrentResourcePools();
+    for(int id: rps.keySet()) {
+      Network network = rps.get(id).getNetwork();
+      try {
+        network.close();
+      } catch (IOException e) {
+        //Cannot do anything about this.
+      }
+    }           
+    rps.clear();
+    //allow the sockets to become available again. 
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
     }
   }
 

--- a/core/src/test/java/dk/alexandra/fresco/framework/network/NetworkCreator.java
+++ b/core/src/test/java/dk/alexandra/fresco/framework/network/NetworkCreator.java
@@ -1,0 +1,75 @@
+package dk.alexandra.fresco.framework.network;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import dk.alexandra.fresco.framework.Party;
+import dk.alexandra.fresco.framework.configuration.ConfigurationException;
+import dk.alexandra.fresco.framework.configuration.NetworkConfiguration;
+import dk.alexandra.fresco.framework.configuration.NetworkConfigurationImpl;
+import dk.alexandra.fresco.framework.sce.configuration.SCEConfiguration;
+import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
+import dk.alexandra.fresco.framework.sce.resources.storage.StreamedStorage;
+
+public class NetworkCreator {
+
+  private static Map<Integer, ResourcePoolImpl> rps = new HashMap<>();
+  
+  public static Map<Integer, ResourcePoolImpl> getCurrentResourcePools() {
+    return rps;
+  }
+  
+  private static Network getNetworkFromConfiguration(SCEConfiguration sceConf,
+      int myId, Map<Integer, Party> parties) {
+    int channelAmount = 1;
+    NetworkConfiguration conf = new NetworkConfigurationImpl(myId, parties);
+    return buildNetwork(conf, channelAmount, sceConf.getNetworkStrategy());
+  }
+
+  private static Network buildNetwork(NetworkConfiguration conf,
+      int channelAmount, NetworkingStrategy networkStrat) {
+    Network network;
+    switch (networkStrat) {
+      case KRYONET:
+        // TODO[PSN]
+        // This might work on mac?
+        network = new KryoNetNetwork();
+        //network = new ScapiNetworkImpl();
+        break;
+      case SCAPI:
+        network = new ScapiNetworkImpl();
+        break;
+      default:
+        throw new ConfigurationException("Unknown networking strategy " + networkStrat);
+    }
+    network.init(conf, channelAmount);
+    return network;
+  }
+  
+  public static ResourcePoolImpl createResourcePool(SCEConfiguration sceConf) throws IOException {
+    int myId = sceConf.getMyId();
+    Map<Integer, Party> parties = sceConf.getParties();
+  
+    StreamedStorage streamedStorage = sceConf.getStreamedStorage();
+    // Secure random by default.
+    Random rand = new Random(0);
+    SecureRandom secRand = new SecureRandom();
+  
+    Network network = getNetworkFromConfiguration(sceConf, myId, parties);
+    network.connect(10000);
+  
+    ResourcePoolImpl resourcePool =
+        new ResourcePoolImpl(myId, parties.size(),
+            network, streamedStorage, rand, secRand);
+      
+    NetworkCreator.rps.put(myId, resourcePool);
+    
+    return resourcePool;
+  
+  }
+
+}

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/AdvancedNumericTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/AdvancedNumericTests.java
@@ -33,7 +33,7 @@ import dk.alexandra.fresco.framework.TestThreadRunner;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -81,7 +81,7 @@ public class AdvancedNumericTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(numerator / denominator),
               convertRepresentation(app.getOutputs()[0].getValue(), modulus));
@@ -128,7 +128,7 @@ public class AdvancedNumericTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(9 / 4),
               app.getOutputs()[0].getValue());
@@ -173,7 +173,7 @@ public class AdvancedNumericTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(numerator / denominator),
               convertRepresentation(app.getOutputs()[0].getValue(), modulus));
@@ -211,7 +211,7 @@ public class AdvancedNumericTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(numerator / denominator),
               app.getOutputs()[0].getValue());
@@ -248,7 +248,7 @@ public class AdvancedNumericTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(9 % 4),
               app.getOutputs()[0].getValue());

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/BasicArithmeticTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/BasicArithmeticTests.java
@@ -49,6 +49,8 @@ import dk.alexandra.fresco.lib.math.integer.exp.PreprocessedExpPipeFactory;
 import dk.alexandra.fresco.lib.math.integer.inv.LocalInversionFactory;
 import dk.alexandra.fresco.lib.math.integer.min.MinInfFracProtocol;
 import java.math.BigInteger;
+import java.util.Arrays;
+
 import org.junit.Assert;
 
 
@@ -572,6 +574,7 @@ public class BasicArithmeticTests {
           secureComputationEngine
               .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
           OInt[] outputs = app.getOutputs();
+          System.out.println(Arrays.toString(outputs));
           Assert.assertEquals(BigInteger.valueOf(2), outputs[0].getValue());
           Assert.assertEquals(BigInteger.valueOf(10), outputs[1].getValue());
           Assert.assertEquals(BigInteger.ZERO, outputs[2].getValue());

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/BasicArithmeticTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/BasicArithmeticTests.java
@@ -33,7 +33,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactory;
@@ -92,7 +92,7 @@ public class BasicArithmeticTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(10),
               app.getOutputs()[0].getValue());
@@ -129,7 +129,7 @@ public class BasicArithmeticTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           if (conf.netConf.getMyId() == 1) {
             Assert.assertEquals(BigInteger.valueOf(10),
                 app.getOutputs()[0].getValue());
@@ -181,7 +181,7 @@ public class BasicArithmeticTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           Assert.assertEquals(BigInteger.valueOf(14),
               app.getOutputs()[0].getValue());
         }
@@ -223,7 +223,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(app.getOutputs()[0].getValue(), BigInteger.ONE);
         }
@@ -264,7 +264,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           checkOutputs(openInputs, app.getOutputs());
         }
@@ -303,7 +303,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           checkOutputs(openInputs, app.getOutputs());
         }
@@ -368,7 +368,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           int sum = 0;
           for (int i : openInputs) {
             sum += i;
@@ -438,7 +438,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(BigInteger.valueOf(10 * (10 + 5)),
               app.getOutputs()[0].getValue());
@@ -483,7 +483,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           OInt[] outputs = app.getOutputs();
           for (OInt o : outputs) {
             Assert.assertEquals(o.getValue(), BigInteger.valueOf(50));
@@ -572,9 +572,8 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           OInt[] outputs = app.getOutputs();
-          System.out.println(Arrays.toString(outputs));
           Assert.assertEquals(BigInteger.valueOf(2), outputs[0].getValue());
           Assert.assertEquals(BigInteger.valueOf(10), outputs[1].getValue());
           Assert.assertEquals(BigInteger.ZERO, outputs[2].getValue());
@@ -642,7 +641,7 @@ public class BasicArithmeticTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
         }
       };
     }

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/ComparisonTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/ComparisonTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactoryImpl;
@@ -102,7 +102,7 @@ public class ComparisonTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					Assert.assertEquals(BigInteger.ONE, app.getOutputs()[0].getValue());
 					Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[1].getValue());
 				}
@@ -111,7 +111,7 @@ public class ComparisonTests {
 	}
 	
 	/**
-	 * Compares the two numbers 3 and 5 and checks that 3 < 5. Also checks that 5 is not < 3
+	 * Compares the two numbers 3 and 5 and checks that 3 == 3. Also checks that 5 != 3
 	 * @author Kasper Damgaard
 	 *
 	 */
@@ -163,7 +163,7 @@ public class ComparisonTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					Assert.assertEquals(BigInteger.ONE, app.getOutputs()[0].getValue());
 					Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[1].getValue());
 				}

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/LogicTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/LogicTests.java
@@ -6,9 +6,9 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.sce.SCEFactory;
 import dk.alexandra.fresco.framework.sce.SecureComputationEngine;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -120,7 +120,7 @@ public class LogicTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ONE, app.getOutputs()[0].getValue());
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[1].getValue());

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/MiMCTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/MiMCTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.KnownSIntProtocol;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
@@ -104,7 +104,7 @@ public class MiMCTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           BigInteger expectedModulus = new BigInteger(
               "2582249878086908589655919172003011874329705792829223512830659356540647622016841194629645353280137831435903171972747493557");
@@ -149,7 +149,7 @@ public class MiMCTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertEquals(app.getOutputs()[0].getValue(), app.getOutputs()[1].getValue());
           secureComputationEngine.shutdownSCE();
@@ -193,7 +193,7 @@ public class MiMCTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           Assert.assertNotEquals(app.getOutputs()[0].getValue(), app.getOutputs()[1].getValue());
           secureComputationEngine.shutdownSCE();
@@ -242,7 +242,7 @@ public class MiMCTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           Assert.assertEquals(x_big, app.getOutputs()[1].getValue());
         }
       };

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/ParallelAndSequenceTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/ParallelAndSequenceTests.java
@@ -6,7 +6,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.helper.builder.OmniBuilder;
@@ -32,9 +32,9 @@ public class ParallelAndSequenceTests {
 					TestApplicationMult multApp = new ParallelAndSequenceTests().new TestApplicationMult();
 
 					secureComputationEngine
-							.runApplication(sumApp, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(sumApp, NetworkCreator.createResourcePool(conf.sceConf));
 					secureComputationEngine.runApplication(multApp,
-							SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							NetworkCreator.createResourcePool(conf.sceConf));
 
 					OInt sum = sumApp.getOutputs()[0];
 					OInt mult = multApp.getOutputs()[0];
@@ -55,9 +55,9 @@ public class ParallelAndSequenceTests {
 					TestApplicationMult multApp = new ParallelAndSequenceTests().new TestApplicationMult();
 
 					secureComputationEngine
-							.runApplication(sumApp, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(sumApp, NetworkCreator.createResourcePool(conf.sceConf));
 					secureComputationEngine.runApplication(multApp,
-							SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							NetworkCreator.createResourcePool(conf.sceConf));
 
           OInt sum = sumApp.getOutputs()[0];
           OInt mult = multApp.getOutputs()[0];

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/SearchingTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/SearchingTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.collections.LookUpProtocolFactory;
@@ -86,7 +86,7 @@ public class SearchingTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           for (int i = 0; i < PAIRS; i++) {
             final int counter = i;
             TestApplication app1 = new TestApplication() {
@@ -116,7 +116,7 @@ public class SearchingTests {
             };
 
             secureComputationEngine
-                .runApplication(app1, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+                .runApplication(app1, NetworkCreator.createResourcePool(conf.sceConf));
 
             Assert.assertEquals(values[i], app1.outputs[0].getValue()
                 .intValue());

--- a/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/SortingTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/arithmetic/SortingTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactoryImpl;
@@ -108,7 +108,7 @@ public class SortingTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[0].getValue());
 					Assert.assertEquals(BigInteger.ONE, app.getOutputs()[1].getValue());
@@ -165,7 +165,7 @@ public class SortingTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ONE, app.getOutputs()[0].getValue());
 					Assert.assertEquals(BigInteger.valueOf(2), app.getOutputs()[1].getValue());
@@ -235,7 +235,7 @@ public class SortingTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[0].getValue()); //unsorted is unsorted
 					Assert.assertEquals(BigInteger.valueOf(0),app.getOutputs()[2].getValue());
@@ -308,7 +308,7 @@ public class SortingTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[0].getValue()); //unsorted is unsorted to start
 					Assert.assertEquals(BigInteger.ONE, app.getOutputs()[1].getValue()); //tobesorted is sorted at the end

--- a/core/src/test/java/dk/alexandra/fresco/lib/bool/BasicBooleanTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/bool/BasicBooleanTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestBoolApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OBool;
 import dk.alexandra.fresco.framework.value.SBool;
 import dk.alexandra.fresco.lib.helper.SingleProtocolProducer;
@@ -72,7 +72,7 @@ public class BasicBooleanTests {
           };
 
           secureComputationEngine.runApplication(app,
-              SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -132,7 +132,7 @@ public class BasicBooleanTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -193,7 +193,7 @@ public class BasicBooleanTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -238,7 +238,7 @@ public class BasicBooleanTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -312,7 +312,7 @@ public class BasicBooleanTests {
           };
 
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;

--- a/core/src/test/java/dk/alexandra/fresco/lib/bool/ComparisonBooleanTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/bool/ComparisonBooleanTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestBoolApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OBool;
 import dk.alexandra.fresco.framework.value.SBool;
 import dk.alexandra.fresco.lib.helper.builder.BasicLogicBuilder;
@@ -77,7 +77,7 @@ public class ComparisonBooleanTests {
 					};
 
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
 						Assert.assertEquals(false,
 								app.getOutputs()[0].getValue());

--- a/core/src/test/java/dk/alexandra/fresco/lib/crypto/BristolCryptoTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/crypto/BristolCryptoTests.java
@@ -35,7 +35,7 @@ import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OBool;
 import dk.alexandra.fresco.framework.value.SBool;
 import dk.alexandra.fresco.lib.field.bool.BasicLogicFactory;
@@ -146,7 +146,7 @@ public class BristolCryptoTests {
           };
 
           secureComputationEngine
-              .runApplication(aesApp, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(aesApp, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -233,7 +233,7 @@ public class BristolCryptoTests {
           };
 
           secureComputationEngine
-              .runApplication(aesApp, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(aesApp, NetworkCreator.createResourcePool(conf.sceConf));
           if (!assertAsExpected) {
             return;
           }
@@ -320,7 +320,7 @@ public class BristolCryptoTests {
           };
 
           secureComputationEngine.runApplication(sha256App,
-              SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -408,7 +408,7 @@ public class BristolCryptoTests {
           };
 
           secureComputationEngine
-              .runApplication(md5App, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(md5App, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -487,7 +487,7 @@ public class BristolCryptoTests {
           };
 
           secureComputationEngine.runApplication(multApp,
-              SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;
@@ -568,7 +568,7 @@ public class BristolCryptoTests {
           };
 
           secureComputationEngine
-              .runApplication(md5App, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(md5App, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;

--- a/core/src/test/java/dk/alexandra/fresco/lib/database/EliminateDuplicatesTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/database/EliminateDuplicatesTests.java
@@ -6,9 +6,9 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.sce.SCEFactory;
 import dk.alexandra.fresco.framework.sce.SecureComputationEngine;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactoryImpl;
@@ -106,7 +106,7 @@ class EliminateDuplicatesTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[0].getValue());
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[1].getValue());
@@ -185,7 +185,7 @@ class EliminateDuplicatesTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ONE, app.getOutputs()[0].getValue());
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[1].getValue());
@@ -266,7 +266,7 @@ class EliminateDuplicatesTests {
             }
           };
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           secureComputationEngine.shutdownSCE();
           Assert.assertEquals(BigInteger.ONE, app.getOutputs()[0].getValue());
           Assert.assertEquals(BigInteger.ZERO, app.getOutputs()[1].getValue());

--- a/core/src/test/java/dk/alexandra/fresco/lib/database/TestDatabase.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/database/TestDatabase.java
@@ -14,7 +14,8 @@ import dk.alexandra.fresco.framework.sce.configuration.TestSCEConfiguration;
 import dk.alexandra.fresco.framework.sce.evaluator.EvaluationStrategy;
 import dk.alexandra.fresco.framework.sce.resources.storage.InMemoryStorage;
 import dk.alexandra.fresco.framework.sce.resources.storage.StorageStrategy;
-import dk.alexandra.fresco.suite.dummy.DummyConfiguration;
+import dk.alexandra.fresco.suite.dummy.bool.DummyConfiguration;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/core/src/test/java/dk/alexandra/fresco/lib/helper/bristol/TestBristolCircuitParser.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/helper/bristol/TestBristolCircuitParser.java
@@ -31,7 +31,8 @@ import static org.junit.Assert.assertEquals;
 import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.value.SBool;
 import dk.alexandra.fresco.lib.field.bool.BasicLogicFactory;
-import dk.alexandra.fresco.suite.dummy.DummyFactory;
+import dk.alexandra.fresco.suite.dummy.bool.DummyFactory;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/core/src/test/java/dk/alexandra/fresco/lib/lp/LPBuildingBlockTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/lp/LPBuildingBlockTests.java
@@ -33,7 +33,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.debug.MarkerProtocolImpl;
@@ -190,7 +190,7 @@ public class LPBuildingBlockTests {
 
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 				}
 			};
 		}
@@ -229,7 +229,7 @@ public class LPBuildingBlockTests {
 					};
 					app.mod = mod;
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					int actualIndex = 0;
 					int sum = 0;
 					BigInteger zero = BigInteger.ZERO;
@@ -268,7 +268,7 @@ public class LPBuildingBlockTests {
 					};
 
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 				}
 			};
 		}
@@ -293,7 +293,7 @@ public class LPBuildingBlockTests {
 					};
 
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 				}
 			};
 		}

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/binary/BinaryOperationsTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/binary/BinaryOperationsTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.RandomAdditiveMaskFactory;
@@ -110,7 +110,7 @@ public class BinaryOperationsTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					BigInteger result = app.getOutputs()[0].getValue();
 					BigInteger remainder = app.getOutputs()[1].getValue();
 					
@@ -174,7 +174,7 @@ public class BinaryOperationsTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           BigInteger output = app.getOutputs()[0].getValue();
 					Assert.assertEquals(input.shiftRight(n), output);
@@ -239,7 +239,7 @@ public class BinaryOperationsTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					BigInteger result = app.getOutputs()[0].getValue();
 					
 					System.out.println(result);

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/division/DivisionTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/division/DivisionTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactory;
@@ -129,7 +129,7 @@ public class DivisionTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					BigInteger quotient = app.getOutputs()[0].getValue();
 					BigInteger remainder = app.getOutputs()[1].getValue();
 					Assert.assertEquals(quotient, x.divide(d));
@@ -201,7 +201,7 @@ public class DivisionTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					for (int i = 0; i < n; i++) {
 						BigInteger actual = app.getOutputs()[i].getValue();
 						

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/exp/ExponentiationTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/exp/ExponentiationTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.RandomAdditiveMaskFactory;
@@ -105,7 +105,7 @@ public class ExponentiationTests {
 						}
 					};
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           BigInteger result = app.getOutputs()[0].getValue();
 					
 					Assert.assertEquals(input.pow(exp), result);

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/log/LogTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/log/LogTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.RandomAdditiveMaskFactory;
@@ -114,7 +114,7 @@ public class LogTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           for (int i = 0; i < x.length; i++) {
 						int actual = app.getOutputs()[i].getValue().intValue();

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/sqrt/SqrtTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/sqrt/SqrtTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactory;
@@ -131,7 +131,7 @@ public class SqrtTests {
 					};
 
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
           for (int i = 0; i < n; i++) {
 						BigInteger actual = app.getOutputs()[i].getValue();

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/stat/StatisticsTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/stat/StatisticsTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.compare.ComparisonProtocolFactory;
@@ -153,7 +153,7 @@ public class StatisticsTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					BigInteger mean1 = app.getOutputs()[0].getValue();
 					BigInteger mean2 = app.getOutputs()[1].getValue();
 					BigInteger variance = app.getOutputs()[2].getValue();

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/mult/BristolMultTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/mult/BristolMultTests.java
@@ -34,7 +34,7 @@ import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OBool;
 import dk.alexandra.fresco.framework.value.SBool;
 import dk.alexandra.fresco.lib.crypto.BristolCryptoFactory;
@@ -148,7 +148,7 @@ public class BristolMultTests {
           };
 
           secureComputationEngine
-              .runApplication(md5App, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(md5App, NetworkCreator.createResourcePool(conf.sceConf));
 
           if (!assertAsExpected) {
             return;

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/polynomial/PolynomialTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/polynomial/PolynomialTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -91,7 +91,7 @@ public class PolynomialTests {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 
 					int f = 0;
 					int power = 1;

--- a/core/src/test/java/dk/alexandra/fresco/lib/statistics/CreditRaterTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/statistics/CreditRaterTest.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -109,7 +109,7 @@ public class CreditRaterTest {
 						}
 					};
 					secureComputationEngine
-							.runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+							.runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
 					Assert.assertThat(result[0].getValue(), Is.is(BigInteger.valueOf(PlaintextCreditRater.calculateScore(values, intervals, scores))));
 				}
 			};

--- a/core/src/test/java/dk/alexandra/fresco/lib/statistics/DEASolverFixedDataTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/statistics/DEASolverFixedDataTest.java
@@ -29,7 +29,7 @@ import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -77,14 +77,14 @@ public class DEASolverFixedDataTest {
 
           DEATestApp app1 = new DEATestApp(dataSet1, type);
           secureComputationEngine
-              .runApplication(app1, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app1, NetworkCreator.createResourcePool(conf.sceConf));
           for (int i = 0; i < app1.solverResult.length; i++) {
             Assert.assertEquals(app1.plainResult[i], postProcess(app1.solverResult[i], type,
                 app1.modulus), 0.0000001);
           }
           DEATestApp app2 = new DEATestApp(dataSet2, type);
           secureComputationEngine
-              .runApplication(app2, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app2, NetworkCreator.createResourcePool(conf.sceConf));
           for (int i = 0; i < app2.solverResult.length; i++) {
             Assert.assertEquals(app2.plainResult[i], postProcess(app2.solverResult[i], type,
                 app1.modulus), 0.0000001);

--- a/core/src/test/java/dk/alexandra/fresco/lib/statistics/DEASolverTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/statistics/DEASolverTests.java
@@ -32,7 +32,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -141,7 +141,7 @@ public class DEASolverTests {
           };
           long startTime = System.nanoTime();
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           long endTime = System.nanoTime();
           System.out.println("============ Seq Time: "
               + ((endTime - startTime) / 1000000));

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/AbstractDummyArithmeticTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/AbstractDummyArithmeticTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2017 FRESCO (http://github.com/aicis/fresco).
+ *
+ * This file is part of the FRESCO project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
+ * and Bouncy Castle. Please see these projects for any further licensing issues.
+ *******************************************************************************/
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import dk.alexandra.fresco.framework.ProtocolEvaluator;
+import dk.alexandra.fresco.framework.TestThreadRunner;
+import dk.alexandra.fresco.framework.configuration.NetworkConfiguration;
+import dk.alexandra.fresco.framework.configuration.TestConfiguration;
+import dk.alexandra.fresco.framework.network.NetworkingStrategy;
+import dk.alexandra.fresco.framework.sce.configuration.TestSCEConfiguration;
+import dk.alexandra.fresco.framework.sce.evaluator.EvaluationStrategy;
+import dk.alexandra.fresco.framework.sce.resources.storage.InMemoryStorage;
+import dk.alexandra.fresco.framework.sce.resources.storage.Storage;
+import dk.alexandra.fresco.suite.ProtocolSuite;
+import dk.alexandra.fresco.suite.dummy.arithmetic.config.DummyArithmeticConfiguration;
+
+/**
+ * Abstract class which handles a lot of boiler plate testing code. This makes
+ * running a single test using different parameters quite easy.
+ *
+ */
+public abstract class AbstractDummyArithmeticTest {
+
+	protected void runTest(TestThreadRunner.TestThreadFactory f, EvaluationStrategy evalStrategy, NetworkingStrategy network, int noOfParties) throws Exception {
+		Level logLevel = Level.INFO;
+
+		int noOfVMThreads = 1;
+		int noOfThreads = 1;
+		List<Integer> ports = new ArrayList<Integer>(noOfParties);
+		for (int i = 1; i <= noOfParties; i++) {
+			ports.add(9000 + i * noOfVMThreads*(noOfParties-1));
+		}
+
+		Map<Integer, NetworkConfiguration> netConf = TestConfiguration.getNetworkConfigurations(noOfParties, ports,
+				logLevel);
+		Map<Integer, TestThreadRunner.TestThreadConfiguration> conf = new HashMap<Integer, TestThreadRunner.TestThreadConfiguration>();
+		for (int playerId : netConf.keySet()) {
+			TestThreadRunner.TestThreadConfiguration ttc = new TestThreadRunner.TestThreadConfiguration();
+			ttc.netConf = netConf.get(playerId);
+
+			BigInteger mod = new BigInteger("6703903964971298549787012499123814115273848577471136527425966013026501536706464354255445443244279389455058889493431223951165286470575994074291745908195329");
+			DummyArithmeticConfiguration dummyConf = new DummyArithmeticConfiguration() {
+              
+              @Override
+              public ProtocolSuite createProtocolSuite(int myPlayerId) {
+                return new DummyArithmeticProtocolSuite(this);
+              }
+              
+              @Override
+              public BigInteger getModulus() {
+                return mod;
+              }
+              
+              @Override
+              public int getMaxBitLength() {
+                return mod.bitLength()/2-1;
+              }
+            };
+
+        
+			boolean useSecureConnection = false; // No tests of secure
+													// connection
+													// here.
+
+			ProtocolEvaluator evaluator = EvaluationStrategy.fromEnum(evalStrategy);
+			Storage storage = new InMemoryStorage();			
+      ttc.sceConf = new TestSCEConfiguration(dummyConf, network, evaluator, noOfThreads,
+          noOfVMThreads, ttc.netConf,
+          storage, useSecureConnection);
+			conf.put(playerId, ttc);
+		}
+		TestThreadRunner.run(f, conf);
+	}
+}

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/AbstractDummyArithmeticTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/AbstractDummyArithmeticTest.java
@@ -84,7 +84,10 @@ public abstract class AbstractDummyArithmeticTest {
               
               @Override
               public int getMaxBitLength() {
-                return mod.bitLength()/2-1;
+                //Should work for up to 255 bits, but for an unknown reason, long-compare fails when allowing that many bits. 
+                //Not really a problem, since actual numbers would most often be a lot smaller than 200 bits. 
+                //return mod.bitLength()/2-1;  
+                return 200;
               }
             };
 

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -1,0 +1,125 @@
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import org.junit.Test;
+
+import dk.alexandra.fresco.framework.network.NetworkingStrategy;
+import dk.alexandra.fresco.framework.sce.evaluator.EvaluationStrategy;
+import dk.alexandra.fresco.lib.arithmetic.BasicArithmeticTests;
+import dk.alexandra.fresco.lib.arithmetic.ComparisonTests;
+import dk.alexandra.fresco.lib.arithmetic.LogicTests;
+import dk.alexandra.fresco.lib.arithmetic.SortingTests;
+import dk.alexandra.fresco.lib.math.integer.stat.StatisticsTests;
+
+public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTest {
+
+  @Test
+  public void test_Copy_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestCopyProtocol(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_Input_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestInput(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_OutputToTarget_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestOutputToSingleParty(), EvaluationStrategy.SEQUENTIAL,
+        NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_AddPublicValue_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestAddPublicValue(), EvaluationStrategy.SEQUENTIAL,
+        NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_Lots_Of_Inputs_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestLotsOfInputs(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET,
+        2);
+  }
+
+  @Test
+  public void test_MultAndAdd_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestSimpleMultAndAdd(), EvaluationStrategy.SEQUENTIAL,
+        NetworkingStrategy.KRYONET,2);
+  }
+
+  @Test
+  public void test_Sum_And_Output_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestSumAndMult(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET,
+        2);
+  }
+
+  @Test
+  public void test_Lots_Of_Inputs_SequentialBatched() throws Exception {
+    runTest(new BasicArithmeticTests.TestLotsOfInputs(), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        NetworkingStrategy.KRYONET, 2);
+  }
+
+  //Comparisons
+
+  @Test
+  public void test_MinInfFrac_Sequential() throws Exception {
+    runTest(new BasicArithmeticTests.TestMinInfFrac(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET,
+        2);
+  }
+
+  @Test
+  public void test_MinInfFrac_SequentialBatched() throws Exception {
+    runTest(new BasicArithmeticTests.TestMinInfFrac(), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_compareLT_Sequential() throws Exception {
+    runTest(new ComparisonTests.TestCompareLT(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_compareEQ_Sequential() throws Exception {
+    runTest(new ComparisonTests.TestCompareEQ(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_isSorted() throws Exception {
+    runTest(new SortingTests.TestIsSorted(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_compareAndSwap() throws Exception {
+    runTest(new SortingTests.TestCompareAndSwap(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+  @Test
+  public void test_Sort() throws Exception {
+    runTest(new SortingTests.TestSort(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+  @Test
+  public void test_Big_Sort() throws Exception {
+    runTest(new SortingTests.TestBigSort(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+  @Test
+  public void test_logic() throws Exception {
+    runTest(new LogicTests.TestLogic(),
+        EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
+  }
+  
+  //Statistics
+  
+  @Test
+  public void test_Exiting_Variable_2_parties() throws Exception {        
+      runTest(new StatisticsTests.TestStatistics(), EvaluationStrategy.SEQUENTIAL_BATCHED, NetworkingStrategy.KRYONET, 2);
+  }
+
+  @Test
+  public void test_Exiting_Variable_3_parties() throws Exception {
+      runTest(new StatisticsTests.TestStatistics(), EvaluationStrategy.SEQUENTIAL_BATCHED, NetworkingStrategy.KRYONET, 3);
+  }
+}

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -8,6 +8,8 @@ import dk.alexandra.fresco.lib.arithmetic.BasicArithmeticTests;
 import dk.alexandra.fresco.lib.arithmetic.ComparisonTests;
 import dk.alexandra.fresco.lib.arithmetic.LogicTests;
 import dk.alexandra.fresco.lib.arithmetic.SortingTests;
+import dk.alexandra.fresco.lib.math.integer.division.DivisionTests;
+import dk.alexandra.fresco.lib.math.integer.sqrt.SqrtTests;
 import dk.alexandra.fresco.lib.math.integer.stat.StatisticsTests;
 
 public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTest {
@@ -59,7 +61,7 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   }
 
   //Comparisons
-
+/*
   @Test
   public void test_MinInfFrac_Sequential() throws Exception {
     runTest(new BasicArithmeticTests.TestMinInfFrac(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET,
@@ -71,7 +73,7 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
     runTest(new BasicArithmeticTests.TestMinInfFrac(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         NetworkingStrategy.KRYONET, 2);
   }
-
+*/
   @Test
   public void test_compareLT_Sequential() throws Exception {
     runTest(new ComparisonTests.TestCompareLT(),
@@ -111,6 +113,23 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
         EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET, 2);
   }
   
+  //Math tests
+  
+  @Test
+  public void test_euclidian_division() throws Exception {
+    runTest(new DivisionTests.TestEuclidianDivision(), EvaluationStrategy.SEQUENTIAL_BATCHED, NetworkingStrategy.KRYONET, 2);
+  }
+  
+  @Test
+  public void test_ss_division() throws Exception {
+    runTest(new DivisionTests.TestSecretSharedDivision(), EvaluationStrategy.SEQUENTIAL_BATCHED, NetworkingStrategy.KRYONET, 2);
+  }
+   
+  @Test
+  public void test_sqrt() throws Exception {
+    runTest(new SqrtTests.TestSquareRoot(), EvaluationStrategy.SEQUENTIAL_BATCHED, NetworkingStrategy.KRYONET, 2);
+  }
+  
   //Statistics
   
   @Test
@@ -122,4 +141,6 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   public void test_Exiting_Variable_3_parties() throws Exception {
       runTest(new StatisticsTests.TestStatistics(), EvaluationStrategy.SEQUENTIAL_BATCHED, NetworkingStrategy.KRYONET, 3);
   }
+  
+  
 }

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -61,7 +61,7 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   }
 
   //Comparisons
-/*
+
   @Test
   public void test_MinInfFrac_Sequential() throws Exception {
     runTest(new BasicArithmeticTests.TestMinInfFrac(), EvaluationStrategy.SEQUENTIAL, NetworkingStrategy.KRYONET,
@@ -73,7 +73,7 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
     runTest(new BasicArithmeticTests.TestMinInfFrac(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         NetworkingStrategy.KRYONET, 2);
   }
-*/
+
   @Test
   public void test_compareLT_Sequential() throws Exception {
     runTest(new ComparisonTests.TestCompareLT(),

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/bool/TestDummyProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/bool/TestDummyProtocolSuite.java
@@ -24,7 +24,7 @@
  * FRESCO uses SCAPI - http://crypto.biu.ac.il/SCAPI, Crypto++, Miracl, NTL,
  * and Bouncy Castle. Please see these projects for any further licensing issues.
  *******************************************************************************/
-package dk.alexandra.fresco.suite.dummy;
+package dk.alexandra.fresco.suite.dummy.bool;
 
 import dk.alexandra.fresco.framework.ProtocolEvaluator;
 import dk.alexandra.fresco.framework.TestThreadRunner;
@@ -39,6 +39,8 @@ import dk.alexandra.fresco.framework.sce.resources.storage.InMemoryStorage;
 import dk.alexandra.fresco.framework.sce.resources.storage.Storage;
 import dk.alexandra.fresco.lib.bool.ComparisonBooleanTests;
 import dk.alexandra.fresco.lib.crypto.BristolCryptoTests;
+import dk.alexandra.fresco.suite.dummy.bool.DummyConfiguration;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/LPSolverTests.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/LPSolverTests.java
@@ -33,7 +33,7 @@ import dk.alexandra.fresco.framework.TestApplication;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadConfiguration;
 import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
+import dk.alexandra.fresco.framework.network.NetworkCreator;
 import dk.alexandra.fresco.framework.value.OInt;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericFactory;
@@ -130,7 +130,7 @@ class LPSolverTests {
           };
           long startTime = System.nanoTime();
           secureComputationEngine
-              .runApplication(app, SecureComputationEngineImpl.createResourcePool(conf.sceConf));
+              .runApplication(app, NetworkCreator.createResourcePool(conf.sceConf));
           long endTime = System.nanoTime();
           System.out.println("============ Seq Time: "
               + ((endTime - startTime) / 1000000));

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzLPSolver2Parties.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzLPSolver2Parties.java
@@ -53,7 +53,7 @@ public class TestSpdzLPSolver2Parties extends AbstractSpdzTest {
 	@Category(IntegrationTest.class)
 	@Test
 	public void test_LPSolver_2_Sequential_Batched_streamed() throws Exception {
-		int noOfThreads = 3;
+		int noOfThreads = 1;
 		InitializeStorage.cleanup();
 		try {
 			InitializeStorage.initStreamedStorage(new FilebasedStreamedStorageImpl(new InMemoryStorage()), 2,


### PR DESCRIPTION
Dummy suite now fully functional. It is able to do everything that spdz can do, and supports the same functionality. 
Reenabled KryoNet. If we cannot make it run on Windows, we should state this, and make the tests platform aware. Tests should really not change because of network, so hiding the network choice from the tests might also be a valid option. 