### PR TITLE
Let SingleProtocolProducer be a Computation to let it break chains of NativeProtocols

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/framework/builder/ProtocolBuilderNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/builder/ProtocolBuilderNumeric.java
@@ -124,13 +124,14 @@ public abstract class ProtocolBuilderNumeric implements ProtocolBuilder {
    * factories that needs to be builders.
    *
    * @param nativeProtocol the native protocol to add
-   * @param <T> the type of the native protocol - pass-through buildable object
-   * @return the original native protocol.
+   * @param <T> the result type of the native protocol
+   * @return a computation that resolves to the result of the native protocol once evaluated
    */
-  public <T extends NativeProtocol> T append(T nativeProtocol) {
+  public <T> Computation<T> append(NativeProtocol<T, ?> nativeProtocol) {
+    SingleProtocolProducer<T> producer = new SingleProtocolProducer<>(nativeProtocol);
     ProtocolBuilderNumeric.ProtocolEntity protocolEntity = createAndAppend();
-    protocolEntity.protocolProducer = SingleProtocolProducer.wrap(nativeProtocol);
-    return nativeProtocol;
+    protocolEntity.protocolProducer = producer;
+    return producer;
   }
 
   // This will go away and should not be used - users should recode their applications to

--- a/core/src/main/java/dk/alexandra/fresco/lib/helper/ParallelProtocolProducer.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/helper/ParallelProtocolProducer.java
@@ -34,13 +34,12 @@ import java.util.ListIterator;
 
 /**
  * If a Parallel protocol has n sub-protocols and is asked to deliver m protocols, it
- * requests the protocols from each of the sub-protocols in a round robin maner.
+ * requests m/n protocols from each of the sub-protocols.
  */
 public class ParallelProtocolProducer implements ProtocolProducer,
     ProtocolProducerCollection {
 
   private LinkedList<ProtocolProducer> cs;
-  private ListIterator<ProtocolProducer> currentIterator;
 
   public ParallelProtocolProducer() {
     cs = new LinkedList<>();
@@ -78,45 +77,47 @@ public class ParallelProtocolProducer implements ProtocolProducer,
 
   @Override
   public boolean hasNextProtocols() {
-    return cs.stream().anyMatch(ProtocolProducer::hasNextProtocols);
+    prune();
+    return !cs.isEmpty();
   }
 
+  /**
+   * Removes any empty protocols.
+   */
+  private void prune() {
+    while (!cs.isEmpty()) {
+      if (cs.getFirst().hasNextProtocols()) {
+        return;
+      } else {
+        cs.remove();
+      }
+    }
+  }
 
   @Override
   public void getNextProtocols(ProtocolCollection protocolCollection) {
-    if (cs.isEmpty()) {
+    // TODO: This is a simple, but very rough implementation.
+    // It requests an equal amount from each subprotocol and only asks once.
+    // A better implementation should try to fill up the protocol array by
+    // requesting further protocols from large protocols if the smaller protocols
+    // run dry.
+    // E.g. this implementation is inferior in that it may return less protocols
+    // than it could.
+    if (cs.size() == 0) {
       return;
     }
-    ProtocolProducer startElement = null;
-    if (currentIterator == null) {
-      currentIterator = cs.listIterator();
-    }
-    if (currentIterator.hasNext()) {
-      startElement = currentIterator.next();
-      startElement.getNextProtocols(protocolCollection);
-    }
-    addProtocolsFromIterator(protocolCollection, null);
-    if (protocolCollection.hasFreeCapacity()) {
-      currentIterator = cs.listIterator();
-      addProtocolsFromIterator(protocolCollection, startElement);
-      if (!currentIterator.hasNext()) {
-        currentIterator = null;
+    ListIterator<ProtocolProducer> x = cs.listIterator();
+    while (x.hasNext()) {
+      ProtocolProducer c = x.next();
+      if (!c.hasNextProtocols()) {
+        x.remove();
+      } else {
+        c.getNextProtocols(protocolCollection);
+      }
+      if (!protocolCollection.hasFreeCapacity()) {
+        return; // We've filled the array.
       }
     }
   }
 
-  private void addProtocolsFromIterator(ProtocolCollection protocolCollection,
-      ProtocolProducer stopElement) {
-    while (currentIterator.hasNext() && protocolCollection.hasFreeCapacity()) {
-      ProtocolProducer producer = currentIterator.next();
-      if (producer == stopElement) {
-        return;
-      }
-      if (producer.hasNextProtocols()) {
-        producer.getNextProtocols(protocolCollection);
-      } else {
-        currentIterator.remove();
-      }
-    }
-  }
 }

--- a/core/src/main/java/dk/alexandra/fresco/lib/helper/SingleProtocolProducer.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/helper/SingleProtocolProducer.java
@@ -8,12 +8,13 @@ import dk.alexandra.fresco.framework.ProtocolProducer;
 /**
  * A protocol producer that only produces a single protocol.
  */
-public class SingleProtocolProducer implements ProtocolProducer {
+public class SingleProtocolProducer<T> implements ProtocolProducer, Computation<T> {
 
-  private NativeProtocol protocol;
+  private NativeProtocol<T, ?> protocol;
   private boolean evaluated = false;
+  private T result;
 
-  private SingleProtocolProducer(NativeProtocol protocol) {
+  public SingleProtocolProducer(NativeProtocol<T, ?> protocol) {
     this.protocol = protocol;
   }
 
@@ -39,6 +40,7 @@ public class SingleProtocolProducer implements ProtocolProducer {
    * @param protocol the protocol to wrap
    * @return the producer
    */
+  @Deprecated
   public static ProtocolProducer wrap(Computation<?> protocol) {
     if (protocol == null) {
       return null;
@@ -55,5 +57,15 @@ public class SingleProtocolProducer implements ProtocolProducer {
     return "SingleProtocolProducer{"
         + "protocol=" + protocol
         + '}';
+  }
+
+  @Override
+  public T out() {
+    if (result == null) {
+      result = protocol.out();
+      // Break chain of native protocols to ensure garbage collection
+      protocol = null;
+    }
+    return result;
   }
 }

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/SpdzBuilder.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/SpdzBuilder.java
@@ -48,54 +48,47 @@ class SpdzBuilder implements BuilderFactoryNumeric {
       @Override
       public Computation<SInt> add(Computation<SInt> a, Computation<SInt> b) {
         SpdzAddProtocol spdzAddProtocol = new SpdzAddProtocol(a, b);
-        protocolBuilder.append(spdzAddProtocol);
-        return spdzAddProtocol;
+        return protocolBuilder.append(spdzAddProtocol);
       }
 
 
       @Override
       public Computation<SInt> add(BigInteger a, Computation<SInt> b) {
         SpdzAddProtocolKnownLeft spdzAddProtocolKnownLeft = new SpdzAddProtocolKnownLeft(a, b);
-        protocolBuilder.append(spdzAddProtocolKnownLeft);
-        return spdzAddProtocolKnownLeft;
+        return protocolBuilder.append(spdzAddProtocolKnownLeft);
       }
 
 
       @Override
       public Computation<SInt> sub(Computation<SInt> a, Computation<SInt> b) {
         SpdzSubtractProtocol spdzSubtractProtocol = new SpdzSubtractProtocol(a, b);
-        protocolBuilder.append(spdzSubtractProtocol);
-        return spdzSubtractProtocol;
+        return protocolBuilder.append(spdzSubtractProtocol);
       }
 
       @Override
       public Computation<SInt> sub(BigInteger a, Computation<SInt> b) {
         SpdzSubtractProtocolKnownLeft spdzSubtractProtocolKnownLeft =
             new SpdzSubtractProtocolKnownLeft(a, b);
-        protocolBuilder.append(spdzSubtractProtocolKnownLeft);
-        return spdzSubtractProtocolKnownLeft;
+        return protocolBuilder.append(spdzSubtractProtocolKnownLeft);
       }
 
       @Override
       public Computation<SInt> sub(Computation<SInt> a, BigInteger b) {
         SpdzSubtractProtocolKnownRight spdzSubtractProtocolKnownRight =
             new SpdzSubtractProtocolKnownRight(a, b);
-        protocolBuilder.append(spdzSubtractProtocolKnownRight);
-        return spdzSubtractProtocolKnownRight;
+        return protocolBuilder.append(spdzSubtractProtocolKnownRight);
       }
 
       @Override
       public Computation<SInt> mult(Computation<SInt> a, Computation<SInt> b) {
         SpdzMultProtocol spdzMultProtocol = new SpdzMultProtocol(a, b);
-        protocolBuilder.append(spdzMultProtocol);
-        return spdzMultProtocol;
+        return protocolBuilder.append(spdzMultProtocol);
       }
 
       @Override
       public Computation<SInt> mult(BigInteger a, Computation<SInt> b) {
         SpdzMultProtocolKnownLeft spdzMultProtocol4 = new SpdzMultProtocolKnownLeft(a, b);
-        protocolBuilder.append(spdzMultProtocol4);
-        return spdzMultProtocol4;
+        return protocolBuilder.append(spdzMultProtocol4);
 
       }
 
@@ -118,15 +111,13 @@ class SpdzBuilder implements BuilderFactoryNumeric {
       public Computation<SInt> input(BigInteger value, int inputParty) {
         SpdzSInt out = spdzFactory.getSInt();
         SpdzInputProtocol protocol = new SpdzInputProtocol(value, out, inputParty);
-        protocolBuilder.append(protocol);
-        return protocol::out;
+        return protocolBuilder.append(protocol);
       }
 
       @Override
       public Computation<BigInteger> open(Computation<SInt> secretShare) {
         SpdzOutputToAllProtocol openProtocol = new SpdzOutputToAllProtocol(secretShare);
-        protocolBuilder.append(openProtocol);
-        return openProtocol;
+        return protocolBuilder.append(openProtocol);
       }
 
       @Override

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzInputProtocol.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/gates/SpdzInputProtocol.java
@@ -37,7 +37,7 @@ import dk.alexandra.fresco.suite.spdz.datatypes.SpdzSInt;
 import dk.alexandra.fresco.suite.spdz.storage.SpdzStorage;
 import java.math.BigInteger;
 
-public class SpdzInputProtocol extends SpdzNativeProtocol<SpdzSInt> {
+public class SpdzInputProtocol extends SpdzNativeProtocol<SInt> {
 
   private SpdzInputMask inputMask; // is opened by this gate.
   protected BigInteger input;


### PR DESCRIPTION
Necessity when working with large, complex computations - i.e. huge LPSolvings.