### PR TITLE
Make Square root work when not specifying exact bit length

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/lib/math/integer/sqrt/SquareRoot.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/math/integer/sqrt/SquareRoot.java
@@ -63,15 +63,17 @@ public class SquareRoot implements ComputationBuilder<SInt> {
 		 */
     int iterations = log2(maxInputLength) + 1;
 
-		/*
-     * First guess is x << maxInputLength / 2 + 1. We add 1 to avoid the
-		 * this to be equal to zero since we divide by it later.
-		 */
+	/*
+     * First guess is 2 ^ (bitlength / 2)
+	 */
     return builder.seq((seq) -> {
-      Computation<SInt> shifted = seq.advancedNumeric()
-          .rightShift(input, maxInputLength / 2);
-      Computation<SInt> addedOne = seq.numeric().add(BigInteger.ONE, shifted);
-      return new IterationState(1, addedOne);
+      Computation<SInt> bitlength = seq.advancedNumeric()
+              .bitLength(input, maxInputLength);
+      Computation<SInt> halfBitlength = seq.advancedNumeric()
+              .rightShift(bitlength);
+      Computation<SInt> estimate = seq.advancedNumeric()
+              .exp(BigInteger.valueOf(2), halfBitlength, BigInteger.valueOf(maxInputLength).bitLength());
+      return new IterationState(1, estimate);
       /*
       * We iterate y[n+1] = (y[n] + x / y[n]) / 2.
 		  */

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/sqrt/SqrtTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/sqrt/SqrtTests.java
@@ -37,12 +37,12 @@ import dk.alexandra.fresco.framework.builder.BuilderFactoryNumeric;
 import dk.alexandra.fresco.framework.builder.NumericBuilder;
 import dk.alexandra.fresco.framework.builder.ProtocolBuilderNumeric;
 import dk.alexandra.fresco.framework.network.ResourcePoolCreator;
-import dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl;
 import dk.alexandra.fresco.framework.value.SInt;
+import org.junit.Assert;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
 
 public class SqrtTests {
 
@@ -53,6 +53,7 @@ public class SqrtTests {
 
       return new TestThread() {
 
+        private final int maxBitLength = 32;
         private final BigInteger[] x = new BigInteger[]{
             BigInteger.valueOf(1234),
             BigInteger.valueOf(12345),
@@ -80,7 +81,7 @@ public class SqrtTests {
                     for (BigInteger input : x) {
                       Computation<SInt> actualInput = sIntFactory.known(input);
                       Computation<SInt> result = builder.advancedNumeric()
-                          .sqrt(actualInput, input.bitLength());
+                          .sqrt(actualInput, maxBitLength);
                       Computation<BigInteger> openResult = builder.numeric().open(result);
                       results.add(openResult);
                     }


### PR DESCRIPTION
Sqrt only worked reliably when you specified the exact bit length of the input. It now works when you specify a maximum bit length.