### PR TITLE
Disables secure channel testing

### DIFF
--- a/demos/aes/src/test/java/dk/alexandra/fresco/demo/TestAESDemo.java
+++ b/demos/aes/src/test/java/dk/alexandra/fresco/demo/TestAESDemo.java
@@ -65,7 +65,7 @@ public class TestAESDemo {
       ttc.netConf = netConf.get(playerId);
       ProtocolSuite<?, ?> suite = new DummyProtocolSuite();
       ProtocolEvaluator<?> evaluator = new SequentialEvaluator();
-      boolean useSecureConnection = true;
+      boolean useSecureConnection = false;
       ttc.sceConf = new TestSCEConfiguration(suite, NetworkingStrategy.KRYONET, evaluator,
           ttc.netConf, useSecureConnection);
       conf.put(playerId, ttc);

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestBasicArithmeticWithEncryption.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestBasicArithmeticWithEncryption.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestBasicArithmeticWithEncryption {
@@ -29,30 +30,32 @@ public class TestBasicArithmeticWithEncryption {
       ports.add(9000 + i * 10);
     }
 
-    Map<Integer, NetworkConfiguration> netConf = TestConfiguration
-        .getNetworkConfigurations(noOfParties, ports);
+    Map<Integer, NetworkConfiguration> netConf =
+        TestConfiguration.getNetworkConfigurations(noOfParties, ports);
     Map<Integer, TestThreadConfiguration> conf = new HashMap<>();
     for (int playerId : netConf.keySet()) {
       TestThreadConfiguration ttc = new TestThreadConfiguration();
       ttc.netConf = netConf.get(playerId);
 
-      SpdzProtocolSuite spdzConf = new SpdzProtocolSuite(150,
-          PreprocessingStrategy.DUMMY, null);
+      SpdzProtocolSuite spdzConf = new SpdzProtocolSuite(150, PreprocessingStrategy.DUMMY, null);
 
-      ProtocolEvaluator evaluator = EvaluationStrategy
-          .fromEnum(EvaluationStrategy.SEQUENTIAL_BATCHED);
-      ttc.sceConf = new TestSCEConfiguration(spdzConf, NetworkingStrategy.KRYONET,
-          evaluator, ttc.netConf, true);
+      ProtocolEvaluator evaluator =
+          EvaluationStrategy.fromEnum(EvaluationStrategy.SEQUENTIAL_BATCHED);
+      ttc.sceConf = new TestSCEConfiguration(spdzConf, NetworkingStrategy.KRYONET, evaluator,
+          ttc.netConf, true);
       conf.put(playerId, ttc);
     }
     TestThreadRunner.run(f, conf);
   }
 
+  // TODO: We need a way to do testing without changing Java's security policies.
+  @Ignore
   @Test
   public void testManyMultsWithEnc2Parties() throws Exception {
     runTest(new BasicArithmeticTests.TestLotsMult(), 2);
   }
 
+  @Ignore
   @Test
   public void testManyMultsWithEnc3Parties() throws Exception {
     runTest(new BasicArithmeticTests.TestLotsMult(), 3);


### PR DESCRIPTION
which should enable a complete test-run without changing Java's security policies.