### PR TITLE
Exception due to MiscOIntGenerator sublist

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/lib/compare/MiscOIntGenerators.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/compare/MiscOIntGenerators.java
@@ -27,8 +27,9 @@
 package dk.alexandra.fresco.lib.compare;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -41,14 +42,14 @@ import java.util.Map;
 public class MiscOIntGenerators {
 
   private Map<Integer, BigInteger[]> coefficientsOfPolynomiums;
-  private LinkedList<BigInteger> twoPowersList;
+  private List<BigInteger> twoPowersList;
   private BigInteger modulus;
 
   public MiscOIntGenerators(BigInteger modulus) {
     coefficientsOfPolynomiums = new HashMap<>();
 
     this.modulus = modulus;
-    twoPowersList = new LinkedList<>();
+    twoPowersList = new ArrayList<>(1);
     twoPowersList.add(BigInteger.ONE);
   }
 
@@ -140,12 +141,16 @@ public class MiscOIntGenerators {
 
 
   public List<BigInteger> getTwoPowersList(int length) {
-    if (length > twoPowersList.size()) {
-      BigInteger currentValue = twoPowersList.getLast();
-      while (length > twoPowersList.size()) {
+    int currentLength = twoPowersList.size();
+    if (length > currentLength) {
+      ArrayList<BigInteger> newTwoPowersList = new ArrayList<>(length);
+      newTwoPowersList.addAll(twoPowersList);
+      BigInteger currentValue = newTwoPowersList.get(currentLength - 1);
+      while (length > newTwoPowersList.size()) {
         currentValue = currentValue.shiftLeft(1);
-        twoPowersList.add(currentValue);
+        newTwoPowersList.add(currentValue);
       }
+      twoPowersList = Collections.unmodifiableList(newTwoPowersList);
     }
     return twoPowersList.subList(0, length);
   }


### PR DESCRIPTION
Changed implementation of getTwoPowersList to not modify a list that has been sublisted as changes to a backing list makes the sublist throw ConcurrentModificationExceptions.

See stacktrace below for an encountered problem. 
```
java.util.ConcurrentModificationException: null
        at java.util.SubList.checkForComodification(Unknown Source)
        at java.util.SubList.size(Unknown Source)
        at dk.alexandra.fresco.lib.math.integer.linalg.InnerProductOpen.lambda$buildComputation$1(InnerProductOpen.java:26)
        at dk.alexandra.fresco.framework.builder.ProtocolBuilderImpl.lambda$par$4(ProtocolBuilderImpl.java:115)
        at dk.alexandra.fresco.framework.builder.BuildStepSingle.createNextStep(BuildStepSingle.java:28)
        at dk.alexandra.fresco.framework.builder.BuildStep.createProducer(BuildStep.java:127)
        at dk.alexandra.fresco.framework.builder.ProtocolBuilderImpl.lambda$par$5(ProtocolBuilderImpl.java:118)
        at dk.alexandra.fresco.lib.helper.LazyProtocolProducerDecorator.getInnerProtocolProducer(LazyProtocolProducerDecorator.java:35)
        at dk.alexandra.fresco.lib.helper.LazyProtocolProducerDecorator.hasNextProtocols(LazyProtocolProducerDecorator.java:30)
        at dk.alexandra.fresco.lib.helper.SequentialProtocolProducer.hasNextProtocols(SequentialProtocolProducer.java:89)
        at dk.alexandra.fresco.lib.helper.LazyProtocolProducerDecorator.hasNextProtocols(LazyProtocolProducerDecorator.java:30)
        at dk.alexandra.fresco.lib.helper.SequentialProtocolProducer.hasNextProtocols(SequentialProtocolProducer.java:89)
        at dk.alexandra.fresco.framework.builder.BuildStepLooping$LoopProtocolProducer.next(BuildStepLooping.java:71)
        at dk.alexandra.fresco.framework.builder.BuildStepLooping$LoopProtocolProducer.hasNextProtocols(BuildStepLooping.java:96)
        at dk.alexandra.fresco.lib.helper.SequentialProtocolProducer.hasNextProtocols(SequentialProtocolProducer.java:86)
        at dk.alexandra.fresco.lib.helper.LazyProtocolProducerDecorator.hasNextProtocols(LazyProtocolProducerDecorator.java:30)
        at dk.alexandra.fresco.lib.helper.ParallelProtocolProducer.getNextProtocols(ParallelProtocolProducer.java:73)
        at dk.alexandra.fresco.lib.helper.SequentialProtocolProducer.getNextProtocols(SequentialProtocolProducer.java:61)
        at com.partisia.mpc.evaluator.SpdzProtocolEvaluator.eval(SpdzProtocolEvaluator.java:45)
        at com.partisia.mpc.evaluator.SpdzProtocolEvaluator.eval(SpdzProtocolEvaluator.java:15)
        at dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl.evalApplication(SecureComputationEngineImpl.java:101)
        at dk.alexandra.fresco.framework.sce.SecureComputationEngineImpl.lambda$startApplication$0(SecureComputationEngineImpl.java:87)
        at java.util.concurrent.FutureTask.run(Unknown Source)
        ... 3 common frames omitted
```