### PR TITLE
fix AesDemo mainClass in pom.xml

### DIFF
--- a/demos/aes/pom.xml
+++ b/demos/aes/pom.xml
@@ -27,7 +27,7 @@
 	            <appendAssemblyId>false</appendAssemblyId>
 	            <archive>
 		            <manifest>
-		              <mainClass>dk.alexandra.fresco.demo.AESDemo</mainClass>
+		              <mainClass>dk.alexandra.fresco.demo.AesDemo</mainClass>
 		            </manifest>
 	            </archive>
 	            <descriptorRefs>


### PR DESCRIPTION
The wrong capitalization in `aes/pom.xml` prevents the generated jar from running on case-sensitive file-systems (i.e., Linux).