### PR TITLE
266 mascot input mask fix

### DIFF
--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -61,6 +61,11 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   }
 
   @Test
+  public void testInputFromAll() throws Exception {
+    runTest(new BasicArithmeticTests.TestInputFromAll<>(), new TestParameters().numParties(2));
+  }
+
+  @Test
   public void test_OutputToTarget_Sequential() throws Exception {
     runTest(new BasicArithmeticTests.TestOutputToSingleParty<>(), new TestParameters()
         .numParties(2)
@@ -307,7 +312,7 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   public void test_permute_rows_non_power_of_two() throws Throwable {
     ArrayList<ArrayList<DRes<SInt>>> fakeRows = new ArrayList<>();
     Matrix<DRes<SInt>> fakeMatrix = new Matrix<>(3, 2, fakeRows);
-    new PermuteRows(() -> fakeMatrix, new int[] {}, 1, true).buildComputation(null);
+    new PermuteRows(() -> fakeMatrix, new int[]{}, 1, true).buildComputation(null);
   }
 
   @Test
@@ -409,11 +414,11 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   public void test_LpSolverDanzigSmallerMod() throws Exception {
     runTest(new LpBuildingBlockTests.TestLpSolver<>(LPSolver.PivotRule.DANZIG),
         new TestParameters()
-        .numParties(2)
-        .modulus(ModulusFinder.findSuitableModulus(128))
-        .maxBitLength(30)
-        .fixedPointPrecesion(8)
-        .performanceLogging(false));
+            .numParties(2)
+            .modulus(ModulusFinder.findSuitableModulus(128))
+            .maxBitLength(30)
+            .fixedPointPrecesion(8)
+            .performanceLogging(false));
   }
 
   @Test
@@ -523,8 +528,8 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   public void test_Minimum_Protocol_2_parties() throws Exception {
     runTest(new MinTests.TestMinimumProtocol<>(),
         new TestParameters()
-        .numParties(2)
-        .performanceLogging(true));
+            .numParties(2)
+            .performanceLogging(true));
     assertThat(performanceLoggers.get(1).getLoggedValues()
         .get(ComparisonLoggerDecorator.ARITHMETIC_COMPARISON_LEQ), is((long) 10));
   }
@@ -533,8 +538,8 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   public void test_Min_Inf_Frac_2_parties() throws Exception {
     runTest(new MinTests.TestMinInfFraction<>(),
         new TestParameters()
-        .numParties(2)
-        .performanceLogging(true));
+            .numParties(2)
+            .performanceLogging(true));
     assertThat(performanceLoggers.get(1).getLoggedValues()
         .get(ComparisonLoggerDecorator.ARITHMETIC_COMPARISON_LEQ), is((long) 10));
   }
@@ -571,7 +576,8 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
 
   @Test
   public void test_debug_tools() throws Exception {
-    runTest(new ArithmeticDebugTests.TestArithmeticOpenAndPrint<>(), new TestParameters().numParties(2));
+    runTest(new ArithmeticDebugTests.TestArithmeticOpenAndPrint<>(),
+        new TestParameters().numParties(2));
   }
 
   @Test
@@ -755,7 +761,7 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   public void test_Real_Sqrt_Uneven_Precision() throws Exception {
     runTest(new MathTests.TestSqrt<>(),
         new TestParameters()
-        .fixedPointPrecesion(BasicFixedPointTests.DEFAULT_PRECISION + 1));
+            .fixedPointPrecesion(BasicFixedPointTests.DEFAULT_PRECISION + 1));
   }
 
   @Test

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzMascotDataSupplier.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzMascotDataSupplier.java
@@ -4,8 +4,8 @@ import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.PaddingAesCtrDrbg;
 import dk.alexandra.fresco.framework.util.StrictBitVector;
-import dk.alexandra.fresco.suite.spdz.datatypes.SpdzInputMask;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzSInt;
+import dk.alexandra.fresco.suite.spdz.datatypes.SpdzInputMask;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzTriple;
 import dk.alexandra.fresco.suite.spdz.preprocessing.MascotFormatConverter;
 import dk.alexandra.fresco.tools.mascot.Mascot;
@@ -21,6 +21,7 @@ import dk.alexandra.fresco.tools.ot.otextension.RotList;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.ArrayDeque;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -42,7 +43,7 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
   private final FieldElement ssk;
 
   private final ArrayDeque<MultiplicationTriple> triples;
-  private final ArrayDeque<InputMask> masks;
+  private final Map<Integer, ArrayDeque<InputMask>> masks;
   private final ArrayDeque<AuthenticatedElement> randomElements;
   private final ArrayDeque<AuthenticatedElement> randomBits;
   private final int prgSeedLength;
@@ -79,7 +80,10 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
     this.modulus = modulus;
     this.preprocessedValues = preprocessedValues;
     this.triples = new ArrayDeque<>();
-    this.masks = new ArrayDeque<>();
+    this.masks = new HashMap<>();
+    for (int partyId = 1; partyId <= numberOfPlayers; partyId++) {
+      masks.put(partyId, new ArrayDeque<>());
+    }
     this.randomElements = new ArrayDeque<>();
     this.randomBits = new ArrayDeque<>();
     this.prgSeedLength = prgSeedLength;
@@ -147,12 +151,13 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
   @Override
   public SpdzInputMask getNextInputMask(int towardPlayerID) {
     ensureInitialized();
-    if (masks.isEmpty()) {
+    ArrayDeque<InputMask> inputMasks = masks.get(towardPlayerID);
+    if (inputMasks.isEmpty()) {
       logger.trace("Getting another mask batch");
-      masks.addAll(mascot.getInputMasks(towardPlayerID, batchSize));
+      inputMasks.addAll(mascot.getInputMasks(towardPlayerID, batchSize));
       logger.trace("Got another mask batch");
     }
-    return MascotFormatConverter.toSpdzInputMask(masks.pop());
+    return MascotFormatConverter.toSpdzInputMask(inputMasks.pop());
   }
 
   @Override

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic2Parties.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic2Parties.java
@@ -51,6 +51,12 @@ public class TestSpdzBasicArithmetic2Parties extends AbstractSpdzTest {
   }
 
   @Test
+  public void testInputFromAll() {
+    runTest(new BasicArithmeticTests.TestInputFromAll<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        PreprocessingStrategy.DUMMY, 2);
+  }
+
+  @Test
   public void test_OutputToTarget_Sequential() {
     runTest(new BasicArithmeticTests.TestOutputToSingleParty<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
@@ -116,5 +122,5 @@ public class TestSpdzBasicArithmetic2Parties extends AbstractSpdzTest {
     runTest(new BasicArithmeticTests.TestOpenWithConversion<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.MASCOT, 2, 16, 16, 16);
   }
-  
+
 }

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic2Parties.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic2Parties.java
@@ -21,92 +21,100 @@ public class TestSpdzBasicArithmetic2Parties extends AbstractSpdzTest {
   // TODO PFF Consider deleting or changing test data to avoid the failure?
   @Ignore
   @Test
-  public void test_Division_Sequential_Batched() throws Exception {
+  public void test_Division_Sequential_Batched() {
     runTest(new TestKnownDivisorDivision<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_Secret_Shared_Division_Sequential_Batched() throws Exception {
+  public void test_Secret_Shared_Division_Sequential_Batched() {
     runTest(new TestDivision<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_Log_Sequential_Batched() throws Exception {
+  public void test_Log_Sequential_Batched() {
     runTest(new TestLogarithm<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_Sqrt_Sequential_Batched() throws Exception {
+  public void test_Sqrt_Sequential_Batched() {
     runTest(new TestSquareRoot<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_Input_Sequential() throws Exception {
-    runTest(new BasicArithmeticTests.TestInput<>(), EvaluationStrategy.SEQUENTIAL,
+  public void test_Input_Sequential() {
+    runTest(new BasicArithmeticTests.TestInput<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_OutputToTarget_Sequential() throws Exception {
+  public void test_OutputToTarget_Sequential() {
     runTest(new BasicArithmeticTests.TestOutputToSingleParty<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_AddPublicValue_Sequential() throws Exception {
+  public void test_AddPublicValue_Sequential() {
     runTest(new BasicArithmeticTests.TestAddPublicValue<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void testOpenWithConversion() throws Exception {
+  public void testOpenWithConversion() {
     runTest(new BasicArithmeticTests.TestOpenWithConversion<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_MultAndAdd_Sequential() throws Exception {
+  public void test_MultAndAdd_Sequential() {
     runTest(new BasicArithmeticTests.TestSimpleMultAndAdd<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_Sum_And_Output_Sequential() throws Exception {
+  public void test_Sum_And_Output_Sequential() {
     runTest(new BasicArithmeticTests.TestSumAndMult<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_MinInfFrac_Sequential() throws Exception {
+  public void test_MinInfFrac_Sequential() {
     runTest(new TestMinInfFrac<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_MinInfFrac_SequentialBatched() throws Exception {
+  public void test_MinInfFrac_SequentialBatched() {
     runTest(new TestMinInfFrac<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 2);
   }
 
   @Test
-  public void test_Input_SequentialBatched_Mascot() throws Exception {
+  public void test_Input_SequentialBatched_Mascot() {
     runTest(new BasicArithmeticTests.TestInput<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
-        PreprocessingStrategy.MASCOT, 2, 16, 16, 4);
+        PreprocessingStrategy.MASCOT, 2, 16, 16, 16);
   }
 
   @Test
-  public void test_Lots_Of_Mults_Sequential_Batched_Different_Modulus() throws Exception {
+  public void testInputFromAllMascot() {
+    runTest(new BasicArithmeticTests.TestInputFromAll<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        PreprocessingStrategy.MASCOT, 2, 16, 16, 16);
+  }
+
+
+  @Test
+  public void test_Lots_Of_Mults_Sequential_Batched_Different_Modulus() {
     runTest(new BasicArithmeticTests.TestLotsMult<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
-        PreprocessingStrategy.DUMMY, 2, 128, 128, 16);
+        PreprocessingStrategy.DUMMY, 2, false, 256, 128, 16);
   }
 
   @Test
-  public void testOpenWithConversionMascot() throws Exception {
+  public void testOpenWithConversionMascot() {
     runTest(new BasicArithmeticTests.TestOpenWithConversion<>(), EvaluationStrategy.SEQUENTIAL,
-        PreprocessingStrategy.MASCOT, 2, 16, 16, 4);
+        PreprocessingStrategy.MASCOT, 2, 16, 16, 16);
   }
+  
 }

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic3Parties.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic3Parties.java
@@ -12,49 +12,55 @@ import org.junit.Test;
 public class TestSpdzBasicArithmetic3Parties extends AbstractSpdzTest {
 
   @Test
-  public void test_Input_Sequential() throws Exception {
+  public void test_Input_Sequential() {
     runTest(new BasicArithmeticTests.TestInput<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Input_SequentialBatched() throws Exception {
+  public void test_Input_SequentialBatched() {
     runTest(new BasicArithmeticTests.TestInput<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Sum_And_Output_Sequential() throws Exception {
+  public void test_Sum_And_Output_Sequential() {
     runTest(new BasicArithmeticTests.TestSumAndMult<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Lots_Of_Mults_Sequential() throws Exception {
+  public void test_Lots_Of_Mults_Sequential() {
     runTest(new BasicArithmeticTests.TestLotsMult<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Lots_Of_Mults_Sequential_Batched() throws Exception {
+  public void test_Lots_Of_Mults_Sequential_Batched() {
     runTest(new BasicArithmeticTests.TestLotsMult<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Alternating_Sequential() throws Exception {
+  public void test_Alternating_Sequential() {
     runTest(new BasicArithmeticTests.TestAlternatingMultAdd<>(), EvaluationStrategy.SEQUENTIAL,
         PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Alternating_Sequential_Batched() throws Exception {
+  public void test_Alternating_Sequential_Batched() {
     runTest(new BasicArithmeticTests.TestAlternatingMultAdd<>(),
         EvaluationStrategy.SEQUENTIAL_BATCHED, PreprocessingStrategy.DUMMY, 3);
   }
 
   @Test
-  public void test_Input_SequentialBatched_Mascot() throws Exception {
+  public void testInputFromAllMascot() {
+    runTest(new BasicArithmeticTests.TestInputFromAll<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        PreprocessingStrategy.MASCOT, 3, 16, 16, 16);
+  }
+
+  @Test
+  public void test_Input_SequentialBatched_Mascot() {
     runTest(new BasicArithmeticTests.TestInput<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.MASCOT, 3, 16, 16, 4);
   }

--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic3Parties.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/TestSpdzBasicArithmetic3Parties.java
@@ -54,6 +54,12 @@ public class TestSpdzBasicArithmetic3Parties extends AbstractSpdzTest {
   }
 
   @Test
+  public void testInputFromAll() {
+    runTest(new BasicArithmeticTests.TestInputFromAll<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        PreprocessingStrategy.DUMMY, 3);
+  }
+
+  @Test
   public void testInputFromAllMascot() {
     runTest(new BasicArithmeticTests.TestInputFromAll<>(), EvaluationStrategy.SEQUENTIAL_BATCHED,
         PreprocessingStrategy.MASCOT, 3, 16, 16, 16);


### PR DESCRIPTION
Addresses issue #266. The mascot data supplier generates pre-processing material in batches and caches the results; this works correctly for party-independent material such as multiplication triples but does not work (w/o modification) for party-dependent input masks. This fix updates the mechanism for pre-generating and caching input masks per party (as opposed to in a single collection).  