### PR TITLE
Polynomial representations

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/lib/math/integer/division/KnownDivisor.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/math/integer/division/KnownDivisor.java
@@ -12,7 +12,7 @@ import java.math.BigInteger;
 /**
  * This protocol is an implementation Euclidean division (finding quotient and remainder) on
  * integers with a secret shared divedend and a known divisor. The dividend must have bitlength
- * smaller than <i>(maxBitLenght - divisorBitLength) / 2</i> where the maxBitLength is avabilable
+ * smaller than <i>(maxBitLenght - divisorBitLength) / 3</i> where the maxBitLength is avabilable
  * via {@link ProtocolBuilderNumeric#getBasicNumericContext().getMaxBitLength()} in order for the
  * division protocol to produce a precise result.
  */

--- a/tools/overdrive/pom.xml
+++ b/tools/overdrive/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>tools-master-pom</artifactId>
+    <groupId>dk.alexandra.fresco</groupId>
+    <version>1.1.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>overdrive</artifactId>
+  <name>fresco-overdrive</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>dk.alexandra.fresco</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPoly.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPoly.java
@@ -1,0 +1,207 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A naive representation of a {@link RingPoly} which simply uses the coefficient representation of
+ * the polynomial.
+ */
+public final class CoefficientRingPoly implements RingPoly<CoefficientRingPoly> {
+
+  private final List<BigInteger> coeffs;
+  private final BigInteger modulus;
+
+  /**
+   * A new polynomial represented as a list of <i>m/2</i> coefficients (lowest to highest degree).
+   * For polynomials of degree lower than <i>m/2 - 1</i> the upper coefficients to be set to zero.
+   *
+   * @param coefficients a list of <i>m/2</i> coefficients
+   * @param modulus the modulus
+   */
+  CoefficientRingPoly(List<BigInteger> coefficients, BigInteger modulus) {
+    this.coeffs = Objects.requireNonNull(coefficients);
+    this.modulus = Objects.requireNonNull(modulus);
+    int size = Objects.requireNonNull(coefficients).size();
+    boolean isTwoPower = size > 0 && (size & (size - 1)) == 0;
+    if (!isTwoPower) {
+      throw new IllegalArgumentException(
+          "Number of coefficients must be a non-zero power of two, but was " + size);
+    }
+  }
+
+  @Override
+  public List<BigInteger> getCoefficients() {
+    return new ArrayList<>(this.coeffs);
+  }
+
+  @Override
+  public int getM() {
+    return this.coeffs.size() * 2;
+  }
+
+  @Override
+  public BigInteger getModulus() {
+    return modulus;
+  }
+
+  @Override
+  public CoefficientRingPoly add(CoefficientRingPoly other) {
+    checkCompatibility(other);
+    for (int i = 0; i < this.coeffs.size(); i++) {
+      this.coeffs.set(i, this.coeffs.get(i).add(other.coeffs.get(i)).mod(modulus));
+    }
+    return this;
+  }
+
+  @Override
+  public CoefficientRingPoly plus(CoefficientRingPoly other) {
+    checkCompatibility(other);
+    List<BigInteger> resCoeffs = new ArrayList<>(this.coeffs.size());
+    for (int i = 0; i < this.coeffs.size(); i++) {
+      resCoeffs.add(this.coeffs.get(i).add(other.coeffs.get(i)).mod(modulus));
+
+    }
+    return new CoefficientRingPoly(resCoeffs, modulus);
+  }
+
+  @Override
+  public CoefficientRingPoly subtract(CoefficientRingPoly other) {
+    checkCompatibility(other);
+    for (int i = 0; i < this.coeffs.size(); i++) {
+      this.coeffs.set(i, this.coeffs.get(i).subtract(other.coeffs.get(i)).mod(modulus));
+    }
+    return this;
+  }
+
+  @Override
+  public CoefficientRingPoly minus(CoefficientRingPoly other) {
+    List<BigInteger> resCoeffs = new ArrayList<>(this.coeffs.size());
+    for (int i = 0; i < this.coeffs.size(); i++) {
+      resCoeffs.add(this.coeffs.get(i).subtract(other.coeffs.get(i)).mod(modulus));
+    }
+    return new CoefficientRingPoly(resCoeffs, modulus);
+  }
+
+  @Override
+  public CoefficientRingPoly multiply(CoefficientRingPoly other) {
+    List<BigInteger> tmp = productCoefficients(other);
+    for (int i = 0; i < tmp.size(); i++) {
+      this.coeffs.set(i, tmp.get(i).mod(modulus));
+    }
+    return this;
+  }
+
+  @Override
+  public CoefficientRingPoly times(CoefficientRingPoly other) {
+    List<BigInteger> tmp = productCoefficients(other);
+    for (int i = 0; i < tmp.size(); i++) {
+      tmp.set(i, tmp.get(i).mod(modulus));
+    }
+    return new CoefficientRingPoly(tmp, modulus);
+
+  }
+
+  /**
+   * Evaluates the polynomial in some point.
+   *
+   * @param x the evaluation point
+   * @return the value of the polynomial in the given point
+   */
+  public BigInteger eval(BigInteger x) {
+    int n = coeffs.size() - 1;
+    BigInteger y = coeffs.get(n);
+    for (int i = n - 1; i >= 0; i--) {
+      y = coeffs.get(i).add(x.multiply(y)).mod(modulus);
+    }
+    return y;
+  }
+
+  /**
+   * Computes the coefficients of a polynomial resulting from the multiplication of this polynomial
+   * with an other polynomial.
+   *
+   * <p>
+   * Generally, we want to do polynomial multiplication using the evaluation representation for
+   * efficiency. So not too much effort has been made to make this fast.
+   * </p>
+   *
+   * @param other the other polynomial
+   * @return the coefficients in the product polynomial
+   */
+  private List<BigInteger> productCoefficients(CoefficientRingPoly other) {
+    checkCompatibility(other);
+    List<BigInteger> tmp = new ArrayList<>(this.coeffs.size());
+    for (int i = 0; i < this.coeffs.size(); i++) {
+      tmp.add(BigInteger.ZERO);
+    }
+    for (int i = 0; i < this.coeffs.size(); i++) {
+      BigInteger coeff = this.coeffs.get(i);
+      for (int j = 0; j < other.coeffs.size(); j++) {
+        int index = (i + j) % this.coeffs.size();
+        // The following is due during the computation modulo x^(m/2) + 1
+        if (index == i + j) {
+          tmp.set(index, tmp.get(index).add(coeff.multiply(other.coeffs.get(j))));
+        } else {
+          tmp.set(index, tmp.get(index).subtract(coeff.multiply(other.coeffs.get(j))));
+        }
+      }
+    }
+    return tmp;
+  }
+
+  /**
+   * Checks a polynomial to see if it is compatible with this polynomial, i.e., if they use the same
+   * modulus and <i>m</i> parameter
+   *
+   * @param other the other polynomial
+   */
+  void checkCompatibility(CoefficientRingPoly other) {
+    Objects.requireNonNull(other);
+    if (other.getM() != this.getM()) {
+      throw new IllegalArgumentException("Non-equal m-parameters. m-parameter of this polynomial "
+          + this.getM() + " while other was " + other.getM());
+    }
+    if (!other.getModulus().equals(this.getModulus())) {
+      throw new IllegalArgumentException("Non-equal moduli. This modulus was " + modulus
+          + " while other was " + other.getModulus());
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof CoefficientRingPoly)) {
+      return false;
+    }
+    CoefficientRingPoly poly = (CoefficientRingPoly) o;
+    if (poly.coeffs.size() != this.coeffs.size()) {
+      return false;
+    }
+    if (!poly.modulus.equals(this.modulus)) {
+      return false;
+    }
+    return this.coeffs.equals(poly.coeffs);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = coeffs.hashCode();
+    result = 31 * result + modulus.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    List<String> terms = new ArrayList<>(coeffs.size());
+    terms.add(coeffs.get(0).toString());
+    for (int i = 1; i < coeffs.size(); i++) {
+      terms.add(coeffs.get(i).toString() + "x^" + i);
+    }
+    return String.join(" + ", terms) + " mod " + modulus;
+  }
+}

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPoly.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPoly.java
@@ -20,15 +20,17 @@ public final class CoefficientRingPoly implements RingPoly<CoefficientRingPoly> 
    *
    * @param coefficients a list of <i>m/2</i> coefficients
    * @param modulus the modulus
+   * @throws IllegalArgumentException
+   *         if any arguments are null or the list of coefficients is a non-two-power size.
    */
   CoefficientRingPoly(List<BigInteger> coefficients, BigInteger modulus) {
     this.coeffs = Objects.requireNonNull(coefficients);
     this.modulus = Objects.requireNonNull(modulus);
     int size = Objects.requireNonNull(coefficients).size();
-    boolean isTwoPower = size > 0 && (size & (size - 1)) == 0;
+    boolean isTwoPower = size > 1 && (size & (size - 1)) == 0;
     if (!isTwoPower) {
       throw new IllegalArgumentException(
-          "Number of coefficients must be a non-zero power of two, but was " + size);
+          "Number of coefficients must be larger than 1 and a power of two, but was " + size);
     }
   }
 

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPoly.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPoly.java
@@ -1,0 +1,209 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * A representation of a {@link RingPoly} which represents the polynomial <i>P</i> as a list of
+ * values <i>P(r<sup>i</sup>)</i> for <i> i &in; Z<sub>m</sub><sup>*</sup></i> and <i>r</i> a
+ * primitive root of unity in <i>Z<sub>q</sub></i>. This is useful as it allows efficient
+ * multiplication of polynomials (<i>O(m)</i> rather than <i>O(m<sup>2</sup>)</i>). The conversion
+ * to and from coefficient representation can be done efficiently using the fast Fourier transform
+ * (actually the number theoretic transform) in <i>O(m*log(m))</i>.
+ *
+ * <p>
+ * Note: since <i>m</i> is taken to be a two-power, Z<sub>m</sub><sup>*</sup> is really just the odd
+ * numbers between <i>0</i> and <i>m</i>. I.e., the length of the list representing the poly in this
+ * representation is equal to that of the coefficient representation.
+ * </p>
+ *
+ *
+ */
+public final class EvaluationRingPoly implements RingPoly<EvaluationRingPoly> {
+
+  private final List<BigInteger> evaluations;
+  private final BigInteger modulus;
+  private BigInteger root;
+
+  private EvaluationRingPoly(List<BigInteger> evaluations, BigInteger root, BigInteger modulus) {
+    this.evaluations = evaluations;
+    this.root = root;
+    this.modulus = modulus;
+  }
+
+  /**
+   * Constructs a polynomial in evaluation representation directly from the evaluations.
+   *
+   * @param evaluations the list of evaluations, the m parameter will be inferred from the length of
+   *        this list
+   * @param root the root of unity in which the polynomial was evaluated (this is need for
+   *        conversion back to coefficient representation)
+   * @param modulus the modulus
+   * @return a new polynomial in evaluation representation
+   */
+  public static EvaluationRingPoly fromEvaluations(List<BigInteger> evaluations, BigInteger root,
+      BigInteger modulus) {
+    return new EvaluationRingPoly(evaluations, root, modulus);
+  }
+
+  /**
+   * Converts a coefficient presentation of a polynomial to evaluation representation.
+   *
+   * @param coefficients the coefficients of the polynomial
+   * @param root the root of unity to use for conversion
+   * @param modulus the modulus
+   * @return a new polynomial in evaluation representation
+   */
+  public static EvaluationRingPoly fromCoefficients(List<BigInteger> coefficients, BigInteger root,
+      BigInteger modulus) {
+    coefficients.addAll(Collections.nCopies(coefficients.size(), BigInteger.ZERO));
+    List<BigInteger> evals = NntCt.getInstance(root, modulus).nntNaive(coefficients); // dont use naive!
+    List<BigInteger> res = new ArrayList<>(coefficients.size() / 2);
+    for (int i = 1; i < evals.size(); i += 2) {
+      res.add(evals.get(i));
+    }
+    return new EvaluationRingPoly(res, root, modulus);
+  }
+
+  @Override
+  public List<BigInteger> getCoefficients() {
+    List<BigInteger> padded = new ArrayList<>(evaluations.size() * 2);
+    for (BigInteger e : evaluations) {
+      padded.add(BigInteger.ZERO);
+      padded.add(e);
+    }
+    padded = NntCt.getInstance(root, modulus).nntInverse(padded);
+    ArrayList<BigInteger> result = new ArrayList<>(evaluations.size());
+    BigInteger inv = BigInteger.valueOf(padded.size()).modInverse(modulus);
+    for (int i = 0; i < evaluations.size(); i++) {
+      BigInteger reduced = padded.get(i).subtract(padded.get(i + evaluations.size())).multiply(inv).mod(modulus);
+      result.add(reduced);
+    }
+    return result;
+  }
+
+  @Override
+  public int getM() {
+    return evaluations.size() * 2;
+  }
+
+  @Override
+  public BigInteger getModulus() {
+    return modulus;
+  }
+
+  @Override
+  public EvaluationRingPoly add(EvaluationRingPoly other) {
+    checkCompatibility(other);
+    for (int i = 0; i < this.evaluations.size(); i++) {
+      this.evaluations.set(i, this.evaluations.get(i).add(other.evaluations.get(i).mod(modulus)));
+    }
+    return this;
+  }
+
+  @Override
+  public EvaluationRingPoly plus(EvaluationRingPoly other) {
+    checkCompatibility(other);
+    List<BigInteger> resEvals = new ArrayList<>(this.evaluations.size());
+    for (int i = 0; i < this.evaluations.size(); i++) {
+      resEvals.add(this.evaluations.get(i).add(other.evaluations.get(i).mod(modulus)));
+    }
+    return new EvaluationRingPoly(resEvals, root, modulus);
+  }
+
+  @Override
+  public EvaluationRingPoly subtract(EvaluationRingPoly other) {
+    checkCompatibility(other);
+    for (int i = 0; i < this.evaluations.size(); i++) {
+      this.evaluations.set(i,
+          this.evaluations.get(i).subtract(other.evaluations.get(i).mod(modulus)));
+    }
+    return this;
+  }
+
+  @Override
+  public EvaluationRingPoly minus(EvaluationRingPoly other) {
+    checkCompatibility(other);
+    List<BigInteger> resEvals = new ArrayList<>(this.evaluations.size());
+    for (int i = 0; i < this.evaluations.size(); i++) {
+      resEvals.add(this.evaluations.get(i).subtract(other.evaluations.get(i).mod(modulus)));
+    }
+    return new EvaluationRingPoly(resEvals, root, modulus);
+  }
+
+  @Override
+  public EvaluationRingPoly multiply(EvaluationRingPoly other) {
+    checkCompatibility(other);
+    for (int i = 0; i < this.evaluations.size(); i++) {
+      this.evaluations.set(i,
+          this.evaluations.get(i).multiply(other.evaluations.get(i).mod(modulus)));
+    }
+    return this;
+  }
+
+  @Override
+  public EvaluationRingPoly times(EvaluationRingPoly other) {
+    checkCompatibility(other);
+    List<BigInteger> resEvals = new ArrayList<>(this.evaluations.size());
+    for (int i = 0; i < this.evaluations.size(); i++) {
+      resEvals.add(this.evaluations.get(i).multiply(other.evaluations.get(i).mod(modulus)));
+    }
+    return new EvaluationRingPoly(resEvals, root, modulus);
+  }
+
+  /**
+   * Checks a polynomial to see if it is compatible with this polynomial, i.e., if they use the same
+   * modulus and <i>m</i> parameter
+   *
+   * @param other the other polynomial
+   */
+  void checkCompatibility(EvaluationRingPoly other) {
+    Objects.requireNonNull(other);
+    if (other.getM() != this.getM()) {
+      throw new IllegalArgumentException("Non-equal m-parameters. m-parameter of first polynomial "
+          + this.getM() + " while second polynimial was " + other.getM());
+    }
+    if (other.getModulus().equals(this.getModulus())) {
+      throw new IllegalArgumentException("Non-equal moduli. Modulus of first polynomial "
+          + this.getModulus() + " while the second polynomials was " + other.getModulus());
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof EvaluationRingPoly)) {
+      return false;
+    }
+    EvaluationRingPoly poly = (EvaluationRingPoly) o;
+    return poly.modulus.equals(this.modulus) && poly.root.equals(this.root)
+        && poly.evaluations.equals(this.evaluations);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = evaluations.hashCode();
+    result = 31 * result + modulus.hashCode();
+    result = 31 * result + root.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("(");
+    List<String> evals = new ArrayList<>(evaluations.size());
+    for (BigInteger e : evaluations) {
+      evals.add(e.toString());
+    }
+    sb.append(String.join(", ", evals));
+    sb.append(")");
+    return sb.toString();
+  }
+
+}

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NaiveNnt.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NaiveNnt.java
@@ -1,0 +1,51 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A naive implementation of the number theoretic transform. Useful for comparison with the FFT
+ * versions.
+ */
+final class NaiveNnt implements NumberTheoreticTransform {
+
+  private BigInteger root;
+  private BigInteger modulus;
+  private BigInteger rootInverse;
+
+  NaiveNnt(BigInteger root, BigInteger modulus) {
+    this.root = root;
+    this.modulus = modulus;
+    this.rootInverse = root.modInverse(modulus);
+  }
+
+  @Override
+  public List<BigInteger> nnt(List<BigInteger> coefficients) {
+    BigInteger myRoot = root;
+    List<BigInteger> evaluations = nntInternal(coefficients, myRoot);
+    return evaluations;
+  }
+
+  @Override
+  public List<BigInteger> nntInverse(List<BigInteger> evaluations) {
+    List<BigInteger> coefficients = nntInternal(evaluations, rootInverse);
+    BigInteger sizeInv = BigInteger.valueOf(evaluations.size()).modInverse(modulus);
+    for (int i = 0; i < coefficients.size(); i++) {
+      coefficients.set(i, coefficients.get(i).multiply(sizeInv).mod(modulus));
+    }
+    return coefficients;
+  }
+
+  private List<BigInteger> nntInternal(List<BigInteger> coefficients, BigInteger myRoot) {
+    CoefficientRingPoly poly = new CoefficientRingPoly(coefficients, modulus);
+    List<BigInteger> evaluations = new ArrayList<>(coefficients.size());
+    BigInteger evaluationPoint = BigInteger.ONE;
+    for (int i = 0; i < coefficients.size(); i++) {
+      evaluations.add(poly.eval(evaluationPoint));
+      evaluationPoint = evaluationPoint.multiply(myRoot).mod(modulus);
+    }
+    return evaluations;
+  }
+
+}

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NntCt.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NntCt.java
@@ -1,0 +1,100 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import dk.alexandra.fresco.framework.util.Pair;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class NntCt implements NumberTheoreticTransform {
+
+  private static Map<Pair<BigInteger, BigInteger>, NntCt> instanceMap = new HashMap<>();
+  private ArrayList<BigInteger> powerTable;
+  private ArrayList<BigInteger> powerTableInverse;
+  private BigInteger root;
+  private BigInteger rootInverse;
+  private BigInteger modulus;
+
+  private NntCt(BigInteger root, BigInteger modulus) {
+    this.root = root;
+    this.modulus = modulus;
+    this.rootInverse = root.modInverse(modulus);
+  }
+
+  public static NntCt getInstance(BigInteger root, BigInteger modulus) {
+    Pair<BigInteger, BigInteger> key = new Pair<>(root, modulus);
+    return instanceMap.computeIfAbsent(key, k -> new NntCt(k.getFirst(), k.getSecond()));
+  }
+
+  @Override
+  public List<BigInteger> nnt(List<BigInteger> coefficients) {
+    ensurePowerTables(coefficients.size());
+    return nntCtRecursive(coefficients, 0, 1, false);
+  }
+
+  @Override
+  public List<BigInteger> nntInverse(List<BigInteger> coefficients) {
+    ensurePowerTables(coefficients.size());
+    return nntCtRecursive(coefficients, 0, 1, true);
+  }
+
+  List<BigInteger> nntNaive(List<BigInteger> coefficients) {
+    CoefficientRingPoly poly = new CoefficientRingPoly(coefficients, modulus);
+    List<BigInteger> evaluations = new ArrayList<>(coefficients.size());
+    BigInteger evaluationPoint = BigInteger.ONE;
+    for (int i = 0; i < coefficients.size(); i++) {
+      evaluations.add(poly.eval(evaluationPoint));
+      evaluationPoint = evaluationPoint.multiply(root).mod(modulus);
+    }
+    return evaluations;
+  }
+
+  List<BigInteger> nntCtRecursive(List<BigInteger> coefficients, int offset, int stride,
+      boolean isInverse) {
+    if (coefficients.size() == stride) {
+      return Collections.singletonList(coefficients.get(offset));
+    }
+    List<BigInteger> even = nntCtRecursive(coefficients, offset, stride * 2, isInverse);
+    List<BigInteger> odd = nntCtRecursive(coefficients, offset + stride, stride * 2, isInverse);
+    List<BigInteger> merged = new ArrayList<>(Collections.nCopies(even.size() + odd.size(), null));
+    for (int i = 0; i < even.size(); i++) {
+      BigInteger e = even.get(i);
+      BigInteger o = odd.get(i);
+      int pwr = i * stride;
+      merged.set(i, e.add(o.multiply(getPowerOf(isInverse, pwr))).mod(modulus));
+      merged.set(i + even.size(),e.subtract(o.multiply(getPowerOf(isInverse, pwr))).mod(modulus));
+    }
+    return merged;
+  }
+
+  private BigInteger getPowerOf(boolean isInverse, int i) {
+    return isInverse ? powerTableInverse.get(i) : powerTable.get(i);
+  }
+
+  private void ensurePowerTables(int length) {
+    if (this.powerTable == null) {
+      this.powerTable = new ArrayList<>(length < 0 ? 0 : length);
+    }
+    if (this.powerTableInverse == null) {
+      this.powerTableInverse = new ArrayList<>(length < 0 ? 0 : length);
+    }
+    ensurePowerTables(length, root, powerTable);
+    ensurePowerTables(length, rootInverse, powerTableInverse);
+  }
+
+  private void ensurePowerTables(int length, BigInteger base, ArrayList<BigInteger> table) {
+    int size = table.size() * 2;
+    if (size < length) {
+      BigInteger tmp = table.isEmpty() ? BigInteger.ONE : table.get(size - 1);
+      table.ensureCapacity(length);
+      for (int i = size; i < length; i++) {
+        table.add(tmp);
+        tmp = tmp.multiply(base).mod(modulus);
+      }
+    }
+  }
+
+
+}

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NntCt.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NntCt.java
@@ -8,7 +8,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class NntCt implements NumberTheoreticTransform {
+/**
+ * An implementation of the number theoretic transform using a simple recursive Cooley Tukey radix-2
+ * approach.
+ *
+ * <p>
+ * Note: While this seem fine for now, there is a lot of FFT optimizations that could be applied.
+ * </p>
+ */
+final class NntCt implements NumberTheoreticTransform {
 
   private static Map<Pair<BigInteger, BigInteger>, NntCt> instanceMap = new HashMap<>();
   private ArrayList<BigInteger> powerTable;
@@ -23,35 +31,38 @@ public final class NntCt implements NumberTheoreticTransform {
     this.rootInverse = root.modInverse(modulus);
   }
 
-  public static NntCt getInstance(BigInteger root, BigInteger modulus) {
+  static NntCt getInstance(BigInteger root, BigInteger modulus) {
     Pair<BigInteger, BigInteger> key = new Pair<>(root, modulus);
     return instanceMap.computeIfAbsent(key, k -> new NntCt(k.getFirst(), k.getSecond()));
   }
 
   @Override
   public List<BigInteger> nnt(List<BigInteger> coefficients) {
+    if (coefficients.isEmpty()) {
+      throw new IllegalArgumentException("Coefficient list is empty.");
+    }
+    isTwoPower(coefficients.size());
     ensurePowerTables(coefficients.size());
     return nntCtRecursive(coefficients, 0, 1, false);
   }
 
   @Override
-  public List<BigInteger> nntInverse(List<BigInteger> coefficients) {
-    ensurePowerTables(coefficients.size());
-    return nntCtRecursive(coefficients, 0, 1, true);
-  }
-
-  List<BigInteger> nntNaive(List<BigInteger> coefficients) {
-    CoefficientRingPoly poly = new CoefficientRingPoly(coefficients, modulus);
-    List<BigInteger> evaluations = new ArrayList<>(coefficients.size());
-    BigInteger evaluationPoint = BigInteger.ONE;
-    for (int i = 0; i < coefficients.size(); i++) {
-      evaluations.add(poly.eval(evaluationPoint));
-      evaluationPoint = evaluationPoint.multiply(root).mod(modulus);
+  public List<BigInteger> nntInverse(List<BigInteger> evaluations) {
+    if (evaluations.isEmpty()) {
+      throw new IllegalArgumentException("Evaluations list is empty.");
     }
-    return evaluations;
+    isTwoPower(evaluations.size());
+    ensurePowerTables(evaluations.size() * 2);
+    List<BigInteger> coefficients = nntCtRecursive(evaluations, 0, 1, true);
+    BigInteger inv = BigInteger.valueOf(evaluations.size()).modInverse(modulus);
+    for (int i = 0; i < evaluations.size(); i++) {
+      BigInteger scaled = coefficients.get(i).multiply(inv).mod(modulus);
+      coefficients.set(i, scaled);
+    }
+    return coefficients;
   }
 
-  List<BigInteger> nntCtRecursive(List<BigInteger> coefficients, int offset, int stride,
+  private List<BigInteger> nntCtRecursive(List<BigInteger> coefficients, int offset, int stride,
       boolean isInverse) {
     if (coefficients.size() == stride) {
       return Collections.singletonList(coefficients.get(offset));
@@ -64,7 +75,7 @@ public final class NntCt implements NumberTheoreticTransform {
       BigInteger o = odd.get(i);
       int pwr = i * stride;
       merged.set(i, e.add(o.multiply(getPowerOf(isInverse, pwr))).mod(modulus));
-      merged.set(i + even.size(),e.subtract(o.multiply(getPowerOf(isInverse, pwr))).mod(modulus));
+      merged.set(i + even.size(), e.subtract(o.multiply(getPowerOf(isInverse, pwr))).mod(modulus));
     }
     return merged;
   }
@@ -75,26 +86,33 @@ public final class NntCt implements NumberTheoreticTransform {
 
   private void ensurePowerTables(int length) {
     if (this.powerTable == null) {
-      this.powerTable = new ArrayList<>(length < 0 ? 0 : length);
+      this.powerTable = new ArrayList<>(length);
     }
     if (this.powerTableInverse == null) {
-      this.powerTableInverse = new ArrayList<>(length < 0 ? 0 : length);
+      this.powerTableInverse = new ArrayList<>(length);
     }
     ensurePowerTables(length, root, powerTable);
     ensurePowerTables(length, rootInverse, powerTableInverse);
   }
 
   private void ensurePowerTables(int length, BigInteger base, ArrayList<BigInteger> table) {
-    int size = table.size() * 2;
+    int size = table.size();
     if (size < length) {
       BigInteger tmp = table.isEmpty() ? BigInteger.ONE : table.get(size - 1);
       table.ensureCapacity(length);
-      for (int i = size; i < length; i++) {
+      for (int i = size; i < length - size; i++) {
         table.add(tmp);
         tmp = tmp.multiply(base).mod(modulus);
       }
     }
   }
 
+  private static void isTwoPower(int size) {
+    boolean isTwoPower = size > 1 && (size & (size - 1)) == 0;
+    if (!isTwoPower) {
+      throw new IllegalArgumentException(
+          "Number of coefficients must be larger than 1 and a power of two, but was " + size);
+    }
+  }
 
 }

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NumberTheoreticTransform.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NumberTheoreticTransform.java
@@ -3,10 +3,26 @@ package dk.alexandra.fresco.overdrive.math;
 import java.math.BigInteger;
 import java.util.List;
 
-public interface NumberTheoreticTransform {
+/**
+ * The number theoretic transform is the Fourier transform in <i>Z_q</i> for some prime <i>q</i>.
+ */
+interface NumberTheoreticTransform {
 
-  public List<BigInteger> nnt(List<BigInteger> coefficients);
+  /**
+   * Computes the forward transform of a list of coefficients.
+   *
+   * @param coefficients the coefficients
+   * @return the forward transform
+   */
+  List<BigInteger> nnt(List<BigInteger> coefficients);
 
-  public List<BigInteger> nntInverse(List<BigInteger> evaluations);
+  /**
+   * Computes the inverse transform of a list of evaluation points as computed by
+   * #{@link NumberTheoreticTransform#nnt(List)}.
+   *
+   * @param evaluations the list of evaluation points
+   * @return the inverse transform
+   */
+  List<BigInteger> nntInverse(List<BigInteger> evaluations);
 
 }

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NumberTheoreticTransform.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/NumberTheoreticTransform.java
@@ -1,0 +1,12 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public interface NumberTheoreticTransform {
+
+  public List<BigInteger> nnt(List<BigInteger> coefficients);
+
+  public List<BigInteger> nntInverse(List<BigInteger> evaluations);
+
+}

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/RingPoly.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/RingPoly.java
@@ -1,0 +1,125 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * Represents a polynomial in the polynomial ring <i>R<sub>q</sub> =
+ * Z<sub>q</sub>[X]/&Phi;<sub>m</sub>(X)</i> where <i>m</i> is some two-power and
+ * <i>&Phi;<sub>m</sub>(X)</i> is the m'th cyclotomic polynomial and <i>q</i> is some prime modulus
+ * <i>q &in; Z<sub>q</sub></i> so that <i>Z<sub>q</sub></i> contains an <i>m</i>'th primitive root
+ * of unity.
+ *
+ * <p>
+ * We note that parameters as specified above implies that
+ * </p>
+ *
+ * <ol>
+ *
+ * <li>&Phi;<sub>m</sub>(X)</i>=X<sup>m/2</sup> + 1, as <i>m</i> is a power of two.
+ * <li>From 1. we have that the polynomials will have degree at most <i>m/2 - 1</i>, i.e., they have
+ * <i>m</i> coefficients
+ * <li>For <i>Z<sub>q</sub></i> to have an <i>m</i>'th primitive root of unity we must pick <i>q</i>
+ * so that <i>m|q-1</i>.
+ * <li>Btw. an <i>m</i>'th primitive root of unity just means that the is an element <i>r &in;
+ * Z<sub>q</sub></i> so that <i>r<sup>m</sup> = 1</i> and <i>r<sup>k</sup> &ne; m</i> for <i>1 &leq;
+ * k &lt; m </i>
+ *
+ * </ol>
+ *
+ *
+ * @param <T> the type of the implementing class
+ */
+public interface RingPoly<T extends RingPoly<T>> {
+
+  /**
+   * Gets a list of <i>m/2</i> coefficients defining the polynomial. The list should be ordered with
+   * the lowest degree coefficient first and the highest degree coefficient last (including
+   * coefficient equal to zero).
+   *
+   * <p>
+   * Note that regardless of the degree of the polynomial this method should return a list of length
+   * exactly <i>m/2</i> (with <i>m</i> defined by {@link #getM()}) elements. For polynomials of
+   * lower degree the upper degree coefficients should be set to zero.
+   * </p>
+   *
+   * @return a list of coefficients
+   */
+  List<BigInteger> getCoefficients();
+
+  /**
+   * Gets the parameter <i>m</i> for the polynomial.
+   *
+   * <p>
+   * Note, that the polynomial can have degree at most <i>m/2 - 1</i>.
+   * </p>
+   *
+   * @return the <i>m</i> parameter.
+   */
+  int getM();
+
+  /**
+   * Gets the integer modulus for coefficients of this polynomial.
+   *
+   * @return the modulus
+   */
+  BigInteger getModulus();
+
+  /**
+   * Adds a polynomial to this polynomial (i.e., mutates this polynomial)
+   *
+   * @param other the other polynomial
+   * @return this polynomial (to support chaining operations)
+   */
+  T add(final T other);
+
+  /**
+   * Computes the result of adding this polynomial to an other polynomial and gives the result as a
+   * new polynomial (i.e, without mutating any of the operands).
+   *
+   * @param other the other polynomial
+   * @return the resulting polynomial
+   */
+  T plus(final T other);
+
+  /**
+   * Subtracts a polynomial from this polynomial (i.e., mutates this polynomial)
+   *
+   * @param other the other polynomial
+   * @return this polynomial (to support chaining operations)
+   */
+  T subtract(final T other);
+
+  /**
+   * Computes the result of subtracting a polynomial from this polynomial and gives the result as a
+   * new polynomial (i.e, without mutating any of the operands).
+   *
+   * @param other the other polynomial
+   * @return the resulting polynomial
+   */
+  T minus(final T other);
+
+
+  /**
+   * Multiplies this polynomial with an other polynomial (i.e., mutates this polynomial)
+   *
+   * @param other the other polynomial
+   * @return this polynomial (to support chaining operations)
+   */
+  T multiply(final T other);
+
+  /**
+   * Computes the result of multiplying this polynomial with an other polynomial and gives the
+   * result as a new polynomial (i.e, without mutating any of the operands).
+   *
+   * @param other the other polynomial
+   * @return the resulting polynomial
+   */
+  T times(final T other);
+
+  /*
+   * TODO: Consider how the modulus q should be represented, and if we should be able to ask a ring
+   * poly for this public BigInteger getModulus();
+   */
+
+}

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/RingPoly.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/RingPoly.java
@@ -18,7 +18,7 @@ import java.util.List;
  *
  * <li>&Phi;<sub>m</sub>(X)</i>=X<sup>m/2</sup> + 1, as <i>m</i> is a power of two.
  * <li>From 1. we have that the polynomials will have degree at most <i>m/2 - 1</i>, i.e., they have
- * <i>m</i> coefficients
+ * <i>m/2</i> coefficients
  * <li>For <i>Z<sub>q</sub></i> to have an <i>m</i>'th primitive root of unity we must pick <i>q</i>
  * so that <i>m|q-1</i>.
  * <li>Btw. an <i>m</i>'th primitive root of unity just means that the is an element <i>r &in;

--- a/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/package-info.java
+++ b/tools/overdrive/src/main/java/dk/alexandra/fresco/overdrive/math/package-info.java
@@ -1,0 +1,17 @@
+/**
+ *
+ * Contains common math functionality used in Overdrive.
+ *
+ * <p>
+ * Specifically, functionality to represent and work with polynomials as required in the Overdrive
+ * variant of the BGV encryption scheme. That is, polynomials in polynomial in the polynomial ring
+ * <i>R<sub>q</sub> = Z<sub>q</sub>[X]/&Phi;<sub>m</sub>(X)</i> where <i>m</i> is some two-power and
+ * <i>&Phi;<sub>m</sub>(X)</i> is the m'th cyclotomic polynomial and <i>q</i> is some prime modulus
+ * <i>q &in; Z<sub>q</sub></i> so that <i>Z<sub>q</sub></i> contains an <i>m</i>'th root of unity.
+ * </p>
+ *
+ * <p>
+ * Also contains functionality to pick correct parameters for the protocol.
+ * </p>
+ */
+package dk.alexandra.fresco.overdrive.math;

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPolyTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPolyTest.java
@@ -22,13 +22,25 @@ public class CoefficientRingPolyTest {
   private BigInteger modulus;
   private int parameterM;
 
+  /**
+   * Sets up a few polynomials to use for tests.
+   *
+   * <p>
+   * The polynomials are
+   * <ul>
+   * <li><i>polyA = 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7</i> and
+   * <li><i>polyB = 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7</i>
+   * </ul>
+   * For these we use the modulus <i>17</i>.
+   * </p>
+   */
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     // The m parameter must be a power of two, here we use 2^4 = 16
     this.parameterM = 16;
     // The modulus must be a prime, p, so that m|p - 1, here we use m + 1 = 17
     this.modulus = BigInteger.valueOf(17);
- // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
+    // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
     List<BigInteger> coeffsA = Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14).stream()
         .map(BigInteger::valueOf).collect(Collectors.toList());
     this.polyA = new CoefficientRingPoly(coeffsA, this.modulus);

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPolyTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/CoefficientRingPolyTest.java
@@ -1,0 +1,212 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CoefficientRingPolyTest {
+
+  private CoefficientRingPoly polyA;
+  private CoefficientRingPoly polyB;
+  private CoefficientRingPoly equalsPolyB;
+
+  private BigInteger modulus;
+  private int parameterM;
+
+  @Before
+  public void setUp() throws Exception {
+    // The m parameter must be a power of two, here we use 2^4 = 16
+    this.parameterM = 16;
+    // The modulus must be a prime, p, so that m|p - 1, here we use m + 1 = 17
+    this.modulus = BigInteger.valueOf(17);
+ // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
+    List<BigInteger> coeffsA = Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyA = new CoefficientRingPoly(coeffsA, this.modulus);
+    // 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7
+    List<BigInteger> coeffsB = Arrays.asList(3, 10, 16, 6, 8, 4, 11, 2).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyB = new CoefficientRingPoly(coeffsB, this.modulus);
+    List<BigInteger> equalsCoeffsB = Arrays.asList(3, 10, 16, 6, 8, 4, 11, 2).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.equalsPolyB = new CoefficientRingPoly(equalsCoeffsB, this.modulus);
+  }
+
+  @Test
+  public void testHashCode() {
+    int hashA = polyA.hashCode();
+    assertEquals(31 * polyA.getCoefficients().hashCode() + modulus.hashCode(), hashA);
+    int hashB = polyB.hashCode();
+    assertEquals(31 * polyB.getCoefficients().hashCode() + modulus.hashCode(), hashB);
+    assertEquals(hashB, equalsPolyB.hashCode());
+  }
+
+  @SuppressWarnings("unlikely-arg-type")
+  @Test
+  public void testEquals() {
+    assertTrue(polyA.equals(polyA));
+    assertTrue(polyB.equals(polyB));
+    assertTrue(polyB.equals(equalsPolyB));
+    assertTrue(equalsPolyB.equals(polyB));
+    assertFalse(equalsPolyB == polyB);
+    assertFalse(equalsPolyB.equals(polyA));
+    assertFalse(polyB.equals(polyA));
+    assertFalse(polyA.equals(null));
+    assertFalse(polyA.equals("Test"));
+    assertFalse("Test".equals(polyA));
+    CoefficientRingPoly differentModPoly =
+        new CoefficientRingPoly(polyA.getCoefficients(), modulus.add(BigInteger.TEN));
+    List<BigInteger> shortCoeffs =
+        Arrays.asList(2, 4, 16, 15).stream().map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly shortPoly = new CoefficientRingPoly(shortCoeffs, modulus);
+    List<BigInteger> longCoeffs =
+        Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14, 2, 4, 16, 15, 12, 4, 5, 14).stream()
+            .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly longPoly = new CoefficientRingPoly(longCoeffs, modulus);
+    assertFalse(polyA.equals(differentModPoly));
+    assertFalse(polyA.equals(shortPoly));
+    assertFalse(polyA.equals(longPoly));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructorNonTwoPowerCoeffs() {
+    List<BigInteger> shortCoeffs =
+        Arrays.asList(2, 4, 16).stream().map(BigInteger::valueOf).collect(Collectors.toList());
+    new CoefficientRingPoly(shortCoeffs, modulus);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructorNoCoeffs() {
+    new CoefficientRingPoly(new ArrayList<BigInteger>(), modulus);
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals("2 + 4x^1 + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7 mod 17", polyA.toString());
+    assertEquals("3 + 10x^1 + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7 mod 17", polyB.toString());
+  }
+
+  @Test
+  public void testGetM() {
+    assertEquals(this.parameterM, polyA.getM());
+  }
+
+  @Test
+  public void testGetModulus() {
+    assertEquals(modulus, polyA.getModulus());
+    assertEquals(modulus, polyB.getModulus());
+  }
+
+  @Test
+  public void testAdd() {
+    List<BigInteger> coeffsSum = Arrays.asList(5, 14, 15, 4, 3, 8, 16, 16).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly polySum = new CoefficientRingPoly(coeffsSum, modulus);
+    CoefficientRingPoly actualSum = polyA.add(polyB);
+    assertEquals(polySum, actualSum);
+    assertEquals(polySum, polyA);
+    assertTrue(polyA == actualSum);
+  }
+
+  @Test
+  public void testPlus() {
+    List<BigInteger> coeffsSum = Arrays.asList(5, 14, 15, 4, 3, 8, 16, 16).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly polySum = new CoefficientRingPoly(coeffsSum, modulus);
+    CoefficientRingPoly actualSum = polyA.plus(polyB);
+    assertEquals(polySum, actualSum);
+    assertNotEquals(polySum, polyA);
+    assertFalse(polyA == actualSum);
+  }
+
+  @Test
+  public void testSubtract() {
+    List<BigInteger> coeffsDifference = Arrays.asList(16, 11, 0, 9, 4, 0, 11, 12).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly polyDiff = new CoefficientRingPoly(coeffsDifference, modulus);
+    CoefficientRingPoly actualDiff = polyA.subtract(polyB);
+    assertEquals(polyDiff, actualDiff);
+    assertEquals(polyDiff, polyA);
+    assertTrue(polyA == actualDiff);
+  }
+
+  @Test
+  public void testMinus() {
+    List<BigInteger> coeffsDifference = Arrays.asList(16, 11, 0, 9, 4, 0, 11, 12).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly polyDiff = new CoefficientRingPoly(coeffsDifference, modulus);
+    CoefficientRingPoly actualDiff = polyA.minus(polyB);
+    assertEquals(polyDiff, actualDiff);
+    assertNotEquals(polyDiff, polyA);
+    assertFalse(polyA == actualDiff);
+
+  }
+
+  @Test
+  public void testMultiply() {
+    List<BigInteger> coeffsProd = Arrays.asList(0, 11, 5, 13, 6, 4, 16, 1).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly polyProd = new CoefficientRingPoly(coeffsProd, modulus);
+    CoefficientRingPoly actualProd = polyA.multiply(polyB);
+    assertEquals(polyProd, actualProd);
+    assertEquals(polyA, actualProd);
+    assertTrue(polyA == actualProd);
+  }
+
+  @Test
+  public void testTimes() {
+    List<BigInteger> coeffsProd = Arrays.asList(0, 11, 5, 13, 6, 4, 16, 1).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly polyProd = new CoefficientRingPoly(coeffsProd, modulus);
+    CoefficientRingPoly actualProd = polyA.times(polyB);
+    assertEquals(polyProd, actualProd);
+    assertNotEquals(polyA, actualProd);
+    assertFalse(polyA == actualProd);
+
+  }
+
+  @Test
+  public void testEval() {
+    assertEquals(BigInteger.valueOf(2), polyA.eval(BigInteger.ZERO));
+    assertEquals(BigInteger.valueOf(7), polyA.eval(BigInteger.valueOf(12)));
+    assertEquals(BigInteger.valueOf(16), polyA.eval(BigInteger.valueOf(10)));
+    assertEquals(BigInteger.valueOf(8), polyA.eval(BigInteger.valueOf(7)));
+    assertEquals(BigInteger.valueOf(12), polyA.eval(BigInteger.valueOf(9)));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testcheckCompatibilityDifferentMod() {
+    CoefficientRingPoly differentModPoly =
+        new CoefficientRingPoly(polyA.getCoefficients(), modulus.add(BigInteger.TEN));
+    polyA.checkCompatibility(differentModPoly);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testcheckCompatibilityLongPoly() {
+    List<BigInteger> longCoeffs =
+        Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14, 2, 4, 16, 15, 12, 4, 5, 14).stream()
+            .map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly longPoly = new CoefficientRingPoly(longCoeffs, modulus);
+    polyA.checkCompatibility(longPoly);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testcheckCompatibilityShortPoly() {
+    List<BigInteger> shortCoeffs =
+        Arrays.asList(2, 4, 16, 15).stream().map(BigInteger::valueOf).collect(Collectors.toList());
+    CoefficientRingPoly shortPoly = new CoefficientRingPoly(shortCoeffs, modulus);
+    polyA.checkCompatibility(shortPoly);
+  }
+
+
+
+}

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPolyTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPolyTest.java
@@ -1,0 +1,124 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import static org.junit.Assert.*;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EvaluationRingPolyTest {
+
+  private int parameterM;
+  private BigInteger modulus;
+  private BigInteger modLong;
+  private CoefficientRingPoly polyA;
+  private CoefficientRingPoly polyLong;
+  private BigInteger root;
+
+  @Before
+  public void setUp() throws Exception {
+    this.parameterM = 16;
+    // The modulus must be a prime, p, so that m|p - 1, here we use 2*m + 1 = 17
+    this.modulus = BigInteger.valueOf(17);
+    this.root = BigInteger.valueOf(3);
+    // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
+    List<BigInteger> coeffsA = Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyA = new CoefficientRingPoly(coeffsA, this.modulus);
+    List<BigInteger> coeffsB = new ArrayList<>(1 << 15);
+    Random rand = new Random();
+    for (int i = 0; i < (1 << 15); i++) {
+      coeffsB.add(new BigInteger(16, rand));
+    }
+    this.polyLong = new CoefficientRingPoly(coeffsB, BigInteger.valueOf((1 << 16) + 1));
+    this.modLong = BigInteger.valueOf((1<<16)+1);
+  }
+
+  @Test
+  public void testHashCode() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testFromEvaluations() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testFromCoefficients() {
+    EvaluationRingPoly e = EvaluationRingPoly.fromCoefficients(polyA.getCoefficients(), root, modulus);
+    assertEquals(polyA.getCoefficients(), e.getCoefficients());
+    EvaluationRingPoly eLong = null;
+    for (int i = 0; i < 100; i++) {
+      eLong = EvaluationRingPoly.fromCoefficients(polyLong.getCoefficients(), root, modLong);
+    }
+    System.out.println(polyLong.getCoefficients().size());
+    assertEquals(polyLong.getCoefficients(), eLong.getCoefficients());
+  }
+
+  @Test
+  public void testGetCoefficients() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testGetM() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testGetModulus() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testAdd() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testPlus() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testSubtract() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testMinus() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testMultiply() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testTimes() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testCheckCompatibility() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testEqualsObject() {
+    fail("Not yet implemented");
+  }
+
+  @Test
+  public void testToString() {
+    fail("Not yet implemented");
+  }
+
+}

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPolyTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPolyTest.java
@@ -59,6 +59,12 @@ public class EvaluationRingPolyTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testNonTwoPowerLength() {
+    BigInteger one = BigInteger.ONE;
+    EvaluationRingPoly.fromCoefficients(Arrays.asList(one, one, one), root, modulus);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testLengthOne() {
     EvaluationRingPoly.fromCoefficients(Arrays.asList(BigInteger.ONE), root, modulus);
   }
 

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPolyTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/EvaluationRingPolyTest.java
@@ -1,6 +1,9 @@
 package dk.alexandra.fresco.overdrive.math;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -13,112 +16,218 @@ import org.junit.Test;
 
 public class EvaluationRingPolyTest {
 
-  private int parameterM;
   private BigInteger modulus;
-  private BigInteger modLong;
-  private CoefficientRingPoly polyA;
-  private CoefficientRingPoly polyLong;
   private BigInteger root;
+  private CoefficientRingPoly polyA;
+  private CoefficientRingPoly polyB;
+  private EvaluationRingPoly evalPolyA;
+  private EvaluationRingPoly evalPolyB;
+  private EvaluationRingPoly equalsEvalPolyB;
 
+  /**
+   * Sets up a few polynomials to use for tests.
+   *
+   * <p>
+   * The polynomials are
+   * <ul>
+   * <li><i>polyA = 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7</i> and
+   * <li><i>polyB = 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7</i>
+   * </ul>
+   * For these we use the root <i>3</i> and modulus <i>17</i>.
+   * </p>
+   */
   @Before
-  public void setUp() throws Exception {
-    this.parameterM = 16;
-    // The modulus must be a prime, p, so that m|p - 1, here we use 2*m + 1 = 17
+  public void setUp() {
+    // The modulus must be a prime, p, so that m|p - 1, here we use m + 1 = 17
     this.modulus = BigInteger.valueOf(17);
     this.root = BigInteger.valueOf(3);
     // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
     List<BigInteger> coeffsA = Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14).stream()
         .map(BigInteger::valueOf).collect(Collectors.toList());
-    this.polyA = new CoefficientRingPoly(coeffsA, this.modulus);
-    List<BigInteger> coeffsB = new ArrayList<>(1 << 15);
-    Random rand = new Random();
-    for (int i = 0; i < (1 << 15); i++) {
-      coeffsB.add(new BigInteger(16, rand));
-    }
-    this.polyLong = new CoefficientRingPoly(coeffsB, BigInteger.valueOf((1 << 16) + 1));
-    this.modLong = BigInteger.valueOf((1<<16)+1);
+    this.polyA = new CoefficientRingPoly(new ArrayList<>(coeffsA), this.modulus);
+    this.evalPolyA = EvaluationRingPoly.fromCoefficients(new ArrayList<>(coeffsA), root, modulus);
+    // 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7
+    List<BigInteger> coeffsB = Arrays.asList(3, 10, 16, 6, 8, 4, 11, 2).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyB = new CoefficientRingPoly(coeffsB, this.modulus);
+    this.evalPolyB = EvaluationRingPoly.fromCoefficients(new ArrayList<>(coeffsB), root, modulus);
+    List<BigInteger> equalsCoeffsB = Arrays.asList(3, 10, 16, 6, 8, 4, 11, 2).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.equalsEvalPolyB =
+        EvaluationRingPoly.fromCoefficients(new ArrayList<>(equalsCoeffsB), root, modulus);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNonTwoPowerLength() {
+    EvaluationRingPoly.fromCoefficients(Arrays.asList(BigInteger.ONE), root, modulus);
   }
 
   @Test
   public void testHashCode() {
-    fail("Not yet implemented");
+    int hashA = evalPolyA.hashCode();
+    assertEquals(
+        31 * (31 * evalPolyA.getEvaluations().hashCode() + modulus.hashCode()) + root.hashCode(),
+        hashA);
+    int hashB = evalPolyB.hashCode();
+    assertEquals(
+        31 * (31 * evalPolyB.getEvaluations().hashCode() + modulus.hashCode()) + root.hashCode(),
+        hashB);
+    assertEquals(hashB, equalsEvalPolyB.hashCode());
   }
 
   @Test
   public void testFromEvaluations() {
-    fail("Not yet implemented");
+    // Compute the evaluations naively
+    List<BigInteger> expectedValues = new ArrayList<>(polyA.getCoefficients().size());
+    BigInteger tmp = root;
+    for (int i = 0; i < polyA.getCoefficients().size(); i++) {
+      expectedValues.add(polyA.eval(tmp));
+      tmp = tmp.multiply(root);
+      tmp = tmp.multiply(root).mod(modulus);
+    }
+    EvaluationRingPoly e = EvaluationRingPoly.fromEvaluations(expectedValues, root, modulus);
+    assertEquals(expectedValues, e.getEvaluations());
+    assertEquals(modulus, e.getModulus());
+    assertEquals(polyA.getCoefficients(), e.getCoefficients());
   }
 
   @Test
   public void testFromCoefficients() {
-    EvaluationRingPoly e = EvaluationRingPoly.fromCoefficients(polyA.getCoefficients(), root, modulus);
-    assertEquals(polyA.getCoefficients(), e.getCoefficients());
-    EvaluationRingPoly eLong = null;
-    for (int i = 0; i < 100; i++) {
-      eLong = EvaluationRingPoly.fromCoefficients(polyLong.getCoefficients(), root, modLong);
+    // Compute the evaluations naively
+    List<BigInteger> expectedValues = new ArrayList<>(polyA.getCoefficients().size());
+    BigInteger tmp = root;
+    for (int i = 0; i < polyA.getCoefficients().size(); i++) {
+      expectedValues.add(polyA.eval(tmp));
+      tmp = tmp.multiply(root);
+      tmp = tmp.multiply(root).mod(modulus);
     }
-    System.out.println(polyLong.getCoefficients().size());
-    assertEquals(polyLong.getCoefficients(), eLong.getCoefficients());
+    assertEquals(expectedValues, evalPolyA.getEvaluations());
+    assertEquals(polyA.getCoefficients(), evalPolyA.getCoefficients());
   }
 
   @Test
-  public void testGetCoefficients() {
-    fail("Not yet implemented");
+  public void testFromCoefficientsLong() {
+    // Note: Doing this naively would take a real long time, so we just check that we can convert
+    // back and forth.
+
+    // Make a long polynomial
+    List<BigInteger> coeffsLong = new ArrayList<>(1 << 15);
+    Random rand = new Random();
+    for (int i = 0; i < (1 << 15); i++) {
+      coeffsLong.add(new BigInteger(16, rand));
+    }
+    CoefficientRingPoly polyLong =
+        new CoefficientRingPoly(coeffsLong, BigInteger.valueOf((1 << 16) + 1));
+    BigInteger modLong = BigInteger.valueOf((1 << 16) + 1);
+    // Convert representation
+    EvaluationRingPoly longE =
+        EvaluationRingPoly.fromCoefficients(polyLong.getCoefficients(), root, modLong);
+    assertEquals(polyLong.getCoefficients(), longE.getCoefficients());
   }
 
   @Test
   public void testGetM() {
-    fail("Not yet implemented");
+    assertEquals(evalPolyA.getM(), polyA.getCoefficients().size() * 2);
+    assertEquals(evalPolyB.getM(), polyB.getCoefficients().size() * 2);
   }
 
   @Test
   public void testGetModulus() {
-    fail("Not yet implemented");
+    assertEquals(modulus, evalPolyA.getModulus());
+    assertEquals(modulus, evalPolyB.getModulus());
   }
 
   @Test
   public void testAdd() {
-    fail("Not yet implemented");
+    EvaluationRingPoly sum = evalPolyA.add(evalPolyB);
+    assertEquals(polyA.plus(polyB).getCoefficients(), sum.getCoefficients());
+    assertEquals(polyA.plus(polyB).getCoefficients(), evalPolyA.getCoefficients());
   }
 
   @Test
   public void testPlus() {
-    fail("Not yet implemented");
+    EvaluationRingPoly sum = evalPolyA.plus(evalPolyB);
+    assertEquals(polyA.plus(polyB).getCoefficients(), sum.getCoefficients());
+    assertNotEquals(polyA.plus(polyB).getCoefficients(), evalPolyA.getCoefficients());
   }
 
   @Test
   public void testSubtract() {
-    fail("Not yet implemented");
+    EvaluationRingPoly diff = evalPolyA.subtract(evalPolyB);
+    assertEquals(polyA.minus(polyB).getCoefficients(), diff.getCoefficients());
+    assertEquals(polyA.minus(polyB).getCoefficients(), evalPolyA.getCoefficients());
   }
 
   @Test
   public void testMinus() {
-    fail("Not yet implemented");
+    EvaluationRingPoly diff = evalPolyA.minus(evalPolyB);
+    assertEquals(polyA.minus(polyB).getCoefficients(), diff.getCoefficients());
+    assertNotEquals(polyA.minus(polyB).getCoefficients(), evalPolyA.getCoefficients());
   }
 
   @Test
   public void testMultiply() {
-    fail("Not yet implemented");
+    EvaluationRingPoly prod = evalPolyA.multiply(evalPolyB);
+    assertEquals(polyA.times(polyB).getCoefficients(), prod.getCoefficients());
+    assertEquals(polyA.times(polyB).getCoefficients(), evalPolyA.getCoefficients());
   }
 
   @Test
   public void testTimes() {
-    fail("Not yet implemented");
+    EvaluationRingPoly prod = evalPolyA.times(evalPolyB);
+    assertEquals(polyA.times(polyB).getCoefficients(), prod.getCoefficients());
+    assertNotEquals(polyA.times(polyB).getCoefficients(), evalPolyA.getCoefficients());
   }
 
-  @Test
-  public void testCheckCompatibility() {
-    fail("Not yet implemented");
+  @Test(expected = IllegalArgumentException.class)
+  public void testCheckCompatibilityWrongMod() {
+    EvaluationRingPoly wrongMod =
+        EvaluationRingPoly.fromEvaluations(evalPolyA.getCoefficients(), root, BigInteger.TEN);
+    evalPolyA.checkCompatibility(wrongMod);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testCheckCompatibilityWrongRoot() {
+    EvaluationRingPoly wrongRoot =
+        EvaluationRingPoly.fromEvaluations(evalPolyA.getCoefficients(), BigInteger.TEN, modulus);
+    evalPolyA.checkCompatibility(wrongRoot);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCheckCompatibilityWrongLength() {
+    EvaluationRingPoly wrongLength = EvaluationRingPoly
+        .fromEvaluations(Arrays.asList(BigInteger.TEN, BigInteger.ONE), BigInteger.TEN, modulus);
+    evalPolyA.checkCompatibility(wrongLength);
+  }
+
+  @SuppressWarnings("unlikely-arg-type")
   @Test
   public void testEqualsObject() {
-    fail("Not yet implemented");
+    assertTrue(evalPolyA.equals(evalPolyA));
+    assertTrue(evalPolyB.equals(evalPolyB));
+    assertTrue(evalPolyB.equals(equalsEvalPolyB));
+    assertTrue(equalsEvalPolyB.equals(evalPolyB));
+    assertFalse(equalsEvalPolyB == evalPolyB);
+    assertFalse(equalsEvalPolyB.equals(evalPolyA));
+    assertFalse(evalPolyB.equals(evalPolyA));
+    assertFalse(evalPolyA.equals(null));
+    assertFalse(evalPolyA.equals("Test"));
+    assertFalse("Test".equals(evalPolyA));
+    EvaluationRingPoly wrongLength = EvaluationRingPoly
+        .fromEvaluations(Arrays.asList(BigInteger.TEN, BigInteger.ONE), BigInteger.TEN, modulus);
+    assertFalse(evalPolyA.equals(wrongLength));
+    EvaluationRingPoly wrongRoot =
+        EvaluationRingPoly.fromEvaluations(evalPolyA.getCoefficients(), BigInteger.TEN, modulus);
+    assertFalse(evalPolyA.equals(wrongRoot));
+    EvaluationRingPoly wrongMod =
+        EvaluationRingPoly.fromEvaluations(evalPolyA.getCoefficients(), root, BigInteger.TEN);
+    assertFalse(evalPolyA.equals(wrongMod));
   }
 
   @Test
   public void testToString() {
-    fail("Not yet implemented");
+    System.out.println(evalPolyA.toString());
+    assertEquals("[16, 16, 7, 0, 7, 8, 7, 6]:3:17", evalPolyA.toString());
   }
 
 }

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/NaiveNntTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/NaiveNntTest.java
@@ -1,0 +1,78 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NaiveNntTest {
+
+
+  private BigInteger modulus;
+  private BigInteger root;
+  private CoefficientRingPoly polyA;
+  private CoefficientRingPoly polyB;
+
+
+  /**
+   * Sets up a few polynomials to use for tests.
+   *
+   * <p>
+   * The polynomials are
+   * <ul>
+   * <li><i>polyA = 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7</i> and
+   * <li><i>polyB = 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7</i>
+   * </ul>
+   * For these we use the root <i>9</i> and modulus <i>17</i>.
+   *
+   * Note: we are using a different root here than for the other tests! This is because here, we are
+   * not padding the poly's with zeros, as we do when computing the evaluation representation.
+   *
+   * </p>
+   */
+  @Before
+  public void setUp() {
+    this.modulus = BigInteger.valueOf(17);
+    this.root = BigInteger.valueOf(9);
+    // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
+    List<BigInteger> coeffsA = Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyA = new CoefficientRingPoly(new ArrayList<>(coeffsA), this.modulus);
+    // 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7
+    List<BigInteger> coeffsB = Arrays.asList(3, 10, 16, 6, 8, 4, 11, 2).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyB = new CoefficientRingPoly(coeffsB, this.modulus);
+  }
+
+
+  @Test
+  public void test() {
+ // Forwards
+    NumberTheoreticTransform nnt = new NaiveNnt(root, modulus);
+    List<BigInteger> expectedA = internalNnt(polyA, root);
+    assertEquals(expectedA, nnt.nnt(polyA.getCoefficients()));
+    List<BigInteger> expectedB = internalNnt(polyB, root);
+    assertEquals(expectedB, nnt.nnt(polyB.getCoefficients()));
+
+    // Backwards
+    assertEquals(polyA.getCoefficients(), nnt.nntInverse(expectedA));
+    assertEquals(polyB.getCoefficients(), nnt.nntInverse(expectedB));
+  }
+
+
+  private List<BigInteger> internalNnt(CoefficientRingPoly myPoly, BigInteger myRoot) {
+    List<BigInteger> expected = new ArrayList<>();
+    BigInteger tmp = BigInteger.ONE;
+    for (int i = 0; i < myPoly.getCoefficients().size(); i++) {
+      expected.add(myPoly.eval(tmp));
+      tmp = tmp.multiply(myRoot).mod(modulus);
+    }
+    return expected;
+  }
+
+}

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/NntCtTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/NntCtTest.java
@@ -86,6 +86,12 @@ public class NntCtTest {
   @Test(expected = IllegalArgumentException.class)
   public void testNonTwoPower() {
     NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
+    nntCt.nntInverse(Arrays.asList(BigInteger.ONE, BigInteger.ONE, BigInteger.ONE));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOneCoeff() {
+    NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
     nntCt.nntInverse(Arrays.asList(BigInteger.ONE));
   }
 

--- a/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/NntCtTest.java
+++ b/tools/overdrive/src/test/java/dk/alexandra/fresco/overdrive/math/NntCtTest.java
@@ -1,0 +1,92 @@
+package dk.alexandra.fresco.overdrive.math;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NntCtTest {
+
+  private BigInteger modulus;
+  private BigInteger root;
+  private CoefficientRingPoly polyA;
+  private CoefficientRingPoly polyB;
+
+
+  /**
+   * Sets up a few polynomials to use for tests.
+   *
+   * <p>
+   * The polynomials are
+   * <ul>
+   * <li><i>polyA = 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7</i> and
+   * <li><i>polyB = 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7</i>
+   * </ul>
+   * For these we use the root <i>9</i> and modulus <i>17</i>.
+   *
+   * Note: we are using a different root here than for the other tests! This is because here, we are
+   * not padding the poly's with zeros, as we do when computing the evaluation representation.
+   *
+   * </p>
+   */
+  @Before
+  public void setUp() {
+    this.modulus = BigInteger.valueOf(17);
+    this.root = BigInteger.valueOf(9);
+    // 2 + 4x + 16x^2 + 15x^3 + 12x^4 + 4x^5 + 5x^6 + 14x^7
+    List<BigInteger> coeffsA = Arrays.asList(2, 4, 16, 15, 12, 4, 5, 14).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyA = new CoefficientRingPoly(new ArrayList<>(coeffsA), this.modulus);
+    // 3 + 10x + 16x^2 + 6x^3 + 8x^4 + 4x^5 + 11x^6 + 2x^7
+    List<BigInteger> coeffsB = Arrays.asList(3, 10, 16, 6, 8, 4, 11, 2).stream()
+        .map(BigInteger::valueOf).collect(Collectors.toList());
+    this.polyB = new CoefficientRingPoly(coeffsB, this.modulus);
+  }
+
+  @Test
+  public void test() {
+    // Forwards
+    NumberTheoreticTransform naiveNnt = new NaiveNnt(root, modulus);
+    NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
+    List<BigInteger> expectedA = naiveNnt.nnt(polyA.getCoefficients());
+    assertEquals(expectedA, nntCt.nnt(polyA.getCoefficients()));
+    List<BigInteger> expectedB = naiveNnt.nnt(polyB.getCoefficients());
+    assertEquals(expectedB, nntCt.nnt(polyB.getCoefficients()));
+
+    // Backwards
+    assertEquals(polyA.getCoefficients(), nntCt.nntInverse(expectedA));
+    assertEquals(polyB.getCoefficients(), nntCt.nntInverse(expectedB));
+  }
+
+  @Test
+  public void testExpandingPowerTable() {
+    NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
+    nntCt.nnt(Arrays.asList(BigInteger.ONE, BigInteger.ONE));
+    nntCt.nnt(Arrays.asList(BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.ONE));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testZeroCoeffsForward() {
+    NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
+    nntCt.nnt(Collections.emptyList());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testZeroCoeffsBackwards() {
+    NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
+    nntCt.nntInverse(Collections.emptyList());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNonTwoPower() {
+    NumberTheoreticTransform nntCt = NntCt.getInstance(root, modulus);
+    nntCt.nntInverse(Arrays.asList(BigInteger.ONE));
+  }
+
+}


### PR DESCRIPTION
Implements ring polynomials represented as straight forward coefficient lists and represented as a list of evaluations of the polynomial on which arithmetic can be done much more efficiently (in particular for multiplication). 

This PR also includes an implementation of the Number Theoretic Transform used to do the conversion between the two representations.

This closes #321 