### PR TITLE
Simplify testing with dummy arithmetic

### DIFF
--- a/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTest.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import static dk.alexandra.fresco.suite.dummy.arithmetic.DummyArithmeticRunner.run;
 import static org.junit.Assert.assertTrue;
 
-public class LinearAlgebraTests {
+public class LinearAlgebraTest {
 
   @Test
   public void testCloseMatrix() {

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTest.java
@@ -1,21 +1,20 @@
 package dk.alexandra.fresco.lib.real;
 
+import static dk.alexandra.fresco.suite.dummy.arithmetic.DummyArithmeticRunner.run;
+import static org.junit.Assert.assertTrue;
+
 import dk.alexandra.fresco.framework.Application;
 import dk.alexandra.fresco.framework.DRes;
 import dk.alexandra.fresco.framework.builder.numeric.ProtocolBuilderNumeric;
 import dk.alexandra.fresco.lib.collections.Matrix;
 import dk.alexandra.fresco.lib.collections.MatrixUtils;
-import org.junit.Test;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
 import java.util.stream.Collectors;
-
-import static dk.alexandra.fresco.suite.dummy.arithmetic.DummyArithmeticRunner.run;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class LinearAlgebraTest {
 

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTest.java
@@ -326,7 +326,6 @@ public class LinearAlgebraTest {
       return () -> new MatrixUtils().unwrapMatrix(opened);
     };
     Matrix<BigDecimal> output = run(testApplication);
-    System.out.println(output);
     for (int i = 0; i < input.getHeight(); i++) {
       RealTestUtils.assertEqual(output.getColumn(i), input.getRow(i), 15);
     }

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/LinearAlgebraTests.java
@@ -1,16 +1,12 @@
 package dk.alexandra.fresco.lib.real;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import dk.alexandra.fresco.framework.Application;
 import dk.alexandra.fresco.framework.DRes;
-import dk.alexandra.fresco.framework.TestThreadRunner.TestThread;
-import dk.alexandra.fresco.framework.TestThreadRunner.TestThreadFactory;
 import dk.alexandra.fresco.framework.builder.numeric.ProtocolBuilderNumeric;
-import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.lib.collections.Matrix;
 import dk.alexandra.fresco.lib.collections.MatrixUtils;
+import org.junit.Test;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,463 +14,324 @@ import java.util.List;
 import java.util.Vector;
 import java.util.stream.Collectors;
 
+import static dk.alexandra.fresco.suite.dummy.arithmetic.DummyArithmeticRunner.run;
+import static org.junit.Assert.assertTrue;
+
 public class LinearAlgebraTests {
 
-  public static class TestCloseFixedMatrix<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testCloseMatrix() {
+    // input
+    Matrix<BigDecimal> input = new Matrix<>(0, 0, new ArrayList<>());
+    // functionality to be tested
+    Matrix<SReal> output = run(root -> {
+      // close inputs
+      DRes<Matrix<DRes<SReal>>> mat = root.realLinAlg().input(input, 1);
+      // unwrap and return result
+      return () -> new MatrixUtils().unwrapMatrix(mat);
+    }, 2);
+    assertTrue(output.getRows().isEmpty());
+  }
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
+  @Test
+  public void testCloseAndOpenMatrix() {
+    // define input and output
+    ArrayList<BigDecimal> rowOne = new ArrayList<>();
+    rowOne.add(BigDecimal.valueOf(1.1));
+    rowOne.add(BigDecimal.valueOf(2.2));
+    ArrayList<BigDecimal> rowTwo = new ArrayList<>();
+    rowTwo.add(BigDecimal.valueOf(3.3));
+    rowTwo.add(BigDecimal.valueOf(4.4));
+    ArrayList<BigDecimal> rowThree = new ArrayList<>();
+    rowThree.add(BigDecimal.valueOf(5.5));
+    rowThree.add(BigDecimal.valueOf(6.6));
+    ArrayList<ArrayList<BigDecimal>> mat = new ArrayList<>();
+    mat.add(rowOne);
+    mat.add(rowTwo);
+    mat.add(rowThree);
+    Matrix<BigDecimal> input = new Matrix<>(3, 2, mat);
 
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        @Override
-        public void test() throws Exception {
-          // input
-          Matrix<BigDecimal> input = new Matrix<>(0, 0, new ArrayList<>());
-          // functionality to be tested
-          Application<Matrix<SReal>, ProtocolBuilderNumeric> testApplication = root -> {
-            // close inputs
-            DRes<Matrix<DRes<SReal>>> mat = root.realLinAlg().input(input, 1);
-            // unwrap and return result
-            return () -> new MatrixUtils().unwrapMatrix(mat);
-          };
-          Matrix<SReal> output = runApplication(testApplication);
-          assertTrue(output.getRows().isEmpty());
-        }
-      };
+    // define functionality to be tested
+    Matrix<BigDecimal> output = run(root -> {
+      DRes<Matrix<DRes<SReal>>> closed = root.realLinAlg().input(input, 1);
+      DRes<Matrix<DRes<BigDecimal>>> opened = root.realLinAlg().openMatrix(closed);
+      return () -> new MatrixUtils().unwrapMatrix(opened);
+    }, 2);
+    for (int i = 0; i < input.getHeight(); i++) {
+      RealTestUtils.assertEqual(output.getRow(i), input.getRow(i), 15);
     }
   }
 
-  public static class TestCloseAndOpenMatrix<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testMatrixAddition() {
+    ArrayList<BigDecimal> rowA1 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2)));
+    ArrayList<BigDecimal> rowA2 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.2)));
+    Matrix<BigDecimal> a = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowA1, rowA2)));
+    ArrayList<BigDecimal> rowB1 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.9), BigDecimal.valueOf(2.9)));
+    ArrayList<BigDecimal> rowB2 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.9), BigDecimal.valueOf(4.8)));
+    Matrix<BigDecimal> b = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowB1, rowB2)));
+    ArrayList<BigDecimal> rowC1 = new ArrayList<>(
+            Arrays.asList(rowA1.get(0).add(rowB1.get(0)), rowA1.get(1).add(rowB1.get(1))));
+    ArrayList<BigDecimal> rowC2 = new ArrayList<>(
+            Arrays.asList(rowA2.get(0).add(rowB2.get(0)), rowA2.get(1).add(rowB2.get(1))));
+    Matrix<BigDecimal> expected =
+            new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowC1, rowC2)));
+    // define functionality to be tested
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-
-        @Override
-        public void test() throws Exception {
-          // define input and output
-          ArrayList<BigDecimal> rowOne = new ArrayList<>();
-          rowOne.add(BigDecimal.valueOf(1.1));
-          rowOne.add(BigDecimal.valueOf(2.2));
-          ArrayList<BigDecimal> rowTwo = new ArrayList<>();
-          rowTwo.add(BigDecimal.valueOf(3.3));
-          rowTwo.add(BigDecimal.valueOf(4.4));
-          ArrayList<BigDecimal> rowThree = new ArrayList<>();
-          rowThree.add(BigDecimal.valueOf(5.5));
-          rowThree.add(BigDecimal.valueOf(6.6));
-          ArrayList<ArrayList<BigDecimal>> mat = new ArrayList<>();
-          mat.add(rowOne);
-          mat.add(rowTwo);
-          mat.add(rowThree);
-          Matrix<BigDecimal> input = new Matrix<>(3, 2, mat);
-
-          // define functionality to be tested
-          Application<Matrix<BigDecimal>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Matrix<DRes<SReal>>> closed = root.realLinAlg().input(input, 1);
-            DRes<Matrix<DRes<BigDecimal>>> opened = root.realLinAlg().openMatrix(closed);
-            return () -> new MatrixUtils().unwrapMatrix(opened);
-          };
-          Matrix<BigDecimal> output = runApplication(testApplication);
-          for (int i = 0; i < input.getHeight(); i++) {
-            RealTestUtils.assertEqual(output.getRow(i), input.getRow(i), 15);
-          }
-        }
-      };
+    List<Matrix<BigDecimal>> output = run(root -> {
+      DRes<Matrix<DRes<SReal>>> closedA = root.realLinAlg().input(a, 1);
+      DRes<Matrix<DRes<SReal>>> closedB = root.realLinAlg().input(b, 1);
+      DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().add(closedA, closedB);
+      DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().add(a, closedB);
+      DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().add(b, closedA);
+      DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
+      DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
+      DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
+      return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
+              new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
+    }, 2);
+    for (int i = 0; i < a.getHeight(); i++) {
+      for (int j = 0; j < output.size(); j++) {
+        RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
+      }
     }
   }
 
-  public static class TestMatrixAddition<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testMatrixSubtraction() {
+    ArrayList<BigDecimal> rowA1 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2)));
+    ArrayList<BigDecimal> rowA2 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.2)));
+    Matrix<BigDecimal> a = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowA1, rowA2)));
+    ArrayList<BigDecimal> rowB1 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.9), BigDecimal.valueOf(2.9)));
+    ArrayList<BigDecimal> rowB2 =
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.9), BigDecimal.valueOf(4.8)));
+    Matrix<BigDecimal> b = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowB1, rowB2)));
+    ArrayList<BigDecimal> rowC1 = new ArrayList<>(Arrays
+            .asList(rowA1.get(0).subtract(rowB1.get(0)), rowA1.get(1).subtract(rowB1.get(1))));
+    ArrayList<BigDecimal> rowC2 = new ArrayList<>(Arrays
+            .asList(rowA2.get(0).subtract(rowB2.get(0)), rowA2.get(1).subtract(rowB2.get(1))));
+    Matrix<BigDecimal> expected =
+            new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowC1, rowC2)));
+    // define functionality to be tested
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-
-        @Override
-        public void test() throws Exception {
-          ArrayList<BigDecimal> rowA1 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2)));
-          ArrayList<BigDecimal> rowA2 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.2)));
-          Matrix<BigDecimal> a = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowA1, rowA2)));
-          ArrayList<BigDecimal> rowB1 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.9), BigDecimal.valueOf(2.9)));
-          ArrayList<BigDecimal> rowB2 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.9), BigDecimal.valueOf(4.8)));
-          Matrix<BigDecimal> b = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowB1, rowB2)));
-          ArrayList<BigDecimal> rowC1 = new ArrayList<>(
-              Arrays.asList(rowA1.get(0).add(rowB1.get(0)), rowA1.get(1).add(rowB1.get(1))));
-          ArrayList<BigDecimal> rowC2 = new ArrayList<>(
-              Arrays.asList(rowA2.get(0).add(rowB2.get(0)), rowA2.get(1).add(rowB2.get(1))));
-          Matrix<BigDecimal> expected =
-              new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowC1, rowC2)));
-          // define functionality to be tested
-          Application<List<Matrix<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Matrix<DRes<SReal>>> closedA = root.realLinAlg().input(a, 1);
-            DRes<Matrix<DRes<SReal>>> closedB = root.realLinAlg().input(b, 1);
-            DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().add(closedA, closedB);
-            DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().add(a, closedB);
-            DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().add(b, closedA);
-            DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
-            DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
-            DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
-            return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
-                new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
-          };
-
-          List<Matrix<BigDecimal>> output = runApplication(testApplication);
-          for (int i = 0; i < a.getHeight(); i++) {
-            for (int j = 0; j < output.size(); j++) {
-              RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
-            }
-          }
-        }
-      };
+    List<Matrix<BigDecimal>> output = run(root -> {
+      DRes<Matrix<DRes<SReal>>> closedA = root.realLinAlg().input(a, 1);
+      DRes<Matrix<DRes<SReal>>> closedB = root.realLinAlg().input(b, 1);
+      DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().sub(closedA, closedB);
+      DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().sub(a, closedB);
+      DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().sub(closedA, b);
+      DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
+      DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
+      DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
+      return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
+              new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
+    }, 2);
+    for (int i = 0; i < a.getHeight(); i++) {
+      for (int j = 0; j < output.size(); j++) {
+        RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
+      }
     }
   }
 
-  public static class TestMatrixSubtraction<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testMatrixScale() {
+    // define input and output
+    ArrayList<ArrayList<BigDecimal>> a = new ArrayList<>(Arrays.asList(
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.0), BigDecimal.valueOf(2.0))),
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0)))));
+    Matrix<BigDecimal> matrix = new Matrix<>(2, 2, a);
+    BigDecimal s = BigDecimal.valueOf(0.1);
+    ArrayList<ArrayList<BigDecimal>> c = new ArrayList<>(Arrays.asList(
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(0.1), BigDecimal.valueOf(0.2))),
+            new ArrayList<>(Arrays.asList(BigDecimal.valueOf(0.3), BigDecimal.valueOf(0.4)))));
+    Matrix<BigDecimal> expected = new Matrix<>(2, 2, c);
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-
-        @Override
-        public void test() throws Exception {
-          ArrayList<BigDecimal> rowA1 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.1), BigDecimal.valueOf(2.2)));
-          ArrayList<BigDecimal> rowA2 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.3), BigDecimal.valueOf(4.2)));
-          Matrix<BigDecimal> a = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowA1, rowA2)));
-          ArrayList<BigDecimal> rowB1 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.9), BigDecimal.valueOf(2.9)));
-          ArrayList<BigDecimal> rowB2 =
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.9), BigDecimal.valueOf(4.8)));
-          Matrix<BigDecimal> b = new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowB1, rowB2)));
-          ArrayList<BigDecimal> rowC1 = new ArrayList<>(Arrays
-              .asList(rowA1.get(0).subtract(rowB1.get(0)), rowA1.get(1).subtract(rowB1.get(1))));
-          ArrayList<BigDecimal> rowC2 = new ArrayList<>(Arrays
-              .asList(rowA2.get(0).subtract(rowB2.get(0)), rowA2.get(1).subtract(rowB2.get(1))));
-          Matrix<BigDecimal> expected =
-              new Matrix<>(2, 2, new ArrayList<>(Arrays.asList(rowC1, rowC2)));
-          // define functionality to be tested
-          Application<List<Matrix<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Matrix<DRes<SReal>>> closedA = root.realLinAlg().input(a, 1);
-            DRes<Matrix<DRes<SReal>>> closedB = root.realLinAlg().input(b, 1);
-            DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().sub(closedA, closedB);
-            DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().sub(a, closedB);
-            DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().sub(closedA, b);
-            DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
-            DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
-            DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
-            return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
-                new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
-          };
-
-          List<Matrix<BigDecimal>> output = runApplication(testApplication);
-          for (int i = 0; i < a.getHeight(); i++) {
-            for (int j = 0; j < output.size(); j++) {
-              RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
-            }
-          }
-        }
-      };
+    // define functionality to be tested
+    List<Matrix<BigDecimal>> output = run(root -> {
+      DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix, 1);
+      DRes<SReal> closedScalar = root.realNumeric().input(s, 1);
+      DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().scale(closedScalar, closedMatrix);
+      DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().scale(s, closedMatrix);
+      DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().scale(closedScalar, matrix);
+      DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
+      DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
+      DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
+      return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
+              new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
+    }, 2);
+    for (int i = 0; i < matrix.getHeight(); i++) {
+      for (int j = 0; j < output.size(); j++) {
+        RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
+      }
     }
   }
 
-  public static class TestMatrixScale<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testMatrixMultiplication() {
+    final int dimension = 50;
+    final int precision = 4;
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-
-        @Override
-        public void test() throws Exception {
-          // define input and output
-          ArrayList<ArrayList<BigDecimal>> a = new ArrayList<>(Arrays.asList(
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(1.0), BigDecimal.valueOf(2.0))),
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(3.0), BigDecimal.valueOf(4.0)))));
-          Matrix<BigDecimal> matrix = new Matrix<>(2, 2, a);
-          BigDecimal s = BigDecimal.valueOf(0.1);
-          ArrayList<ArrayList<BigDecimal>> c = new ArrayList<>(Arrays.asList(
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(0.1), BigDecimal.valueOf(0.2))),
-              new ArrayList<>(Arrays.asList(BigDecimal.valueOf(0.3), BigDecimal.valueOf(0.4)))));
-          Matrix<BigDecimal> expected = new Matrix<>(2, 2, c);
-
-          // define functionality to be tested
-          Application<List<Matrix<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix, 1);
-            DRes<SReal> closedScalar = root.realNumeric().input(s, 1);
-            DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().scale(closedScalar, closedMatrix);
-            DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().scale(s, closedMatrix);
-            DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().scale(closedScalar, matrix);
-            DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
-            DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
-            DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
-            return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
-                new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
-          };
-          List<Matrix<BigDecimal>> output = runApplication(testApplication);
-          for (int i = 0; i < matrix.getHeight(); i++) {
-            for (int j = 0; j < output.size(); j++) {
-              RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
-            }
-          }
-        }
-      };
+    Matrix<BigDecimal> matrix = allOneMatrix(dimension, dimension, precision);
+    Matrix<BigDecimal> vector = allOneMatrix(dimension, 1, precision);
+    // Expected output
+    ArrayList<ArrayList<BigDecimal>> e = new ArrayList<>();
+    for (int i = 0; i < dimension; i++) {
+      ArrayList<BigDecimal> row = new ArrayList<>(dimension);
+      row.add(BigDecimal.valueOf(dimension).setScale(1));
+      e.add(row);
+    }
+    Matrix<BigDecimal> expected = new Matrix<>(dimension, 1, e);
+    List<Matrix<BigDecimal>> output = run(root -> {
+      DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix, 1);
+      DRes<Matrix<DRes<SReal>>> closedVector = root.realLinAlg().input(vector, 1);
+      DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().mult(closedMatrix, closedVector);
+      DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().mult(matrix, closedVector);
+      DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().mult(closedMatrix, vector);
+      DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
+      DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
+      DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
+      return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
+              new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
+    }, 2);
+    for (int i = 0; i < matrix.getHeight(); i++) {
+      for (int j = 0; j < output.size(); j++) {
+        RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
+      }
     }
   }
 
-  public static class TestMatrixMultiplication<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testMatrixOperate() {
+    final int dimension = 50;
+    final int precision = 4;
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        final int dimension = 50;
-        final int precision = 4;
+    Matrix<BigDecimal> matrix = allOneMatrix(dimension, dimension, precision);
+    Vector<BigDecimal> vector = allOneVector(dimension, precision);
+    Vector<BigDecimal> expected = new Vector<>(dimension);
+    for (int i = 0; i < dimension; i++) {
+      expected.add(BigDecimal.valueOf(dimension).setScale(1));
+    }
+    List<Vector<BigDecimal>> output = run(root -> {
 
-        @Override
-        public void test() throws Exception {
-          Matrix<BigDecimal> matrix = allOneMatrix(dimension, dimension, precision);
-          Matrix<BigDecimal> vector = allOneMatrix(dimension, 1, precision);
-          // Expected output
-          ArrayList<ArrayList<BigDecimal>> e = new ArrayList<>();
-          for (int i = 0; i < dimension; i++) {
-            ArrayList<BigDecimal> row = new ArrayList<>(dimension);
-            row.add(BigDecimal.valueOf(dimension).setScale(1));
-            e.add(row);
-          }
-          Matrix<BigDecimal> expected = new Matrix<>(dimension, 1, e);
-          Application<List<Matrix<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix, 1);
-            DRes<Matrix<DRes<SReal>>> closedVector = root.realLinAlg().input(vector, 1);
-            DRes<Matrix<DRes<SReal>>> res1 = root.realLinAlg().mult(closedMatrix, closedVector);
-            DRes<Matrix<DRes<SReal>>> res2 = root.realLinAlg().mult(matrix, closedVector);
-            DRes<Matrix<DRes<SReal>>> res3 = root.realLinAlg().mult(closedMatrix, vector);
-            DRes<Matrix<DRes<BigDecimal>>> open1 = root.realLinAlg().openMatrix(res1);
-            DRes<Matrix<DRes<BigDecimal>>> open2 = root.realLinAlg().openMatrix(res2);
-            DRes<Matrix<DRes<BigDecimal>>> open3 = root.realLinAlg().openMatrix(res3);
-            return () -> Arrays.asList(new MatrixUtils().unwrapMatrix(open1),
-                new MatrixUtils().unwrapMatrix(open2), new MatrixUtils().unwrapMatrix(open3));
-          };
-          List<Matrix<BigDecimal>> output = runApplication(testApplication);
-          for (int i = 0; i < matrix.getHeight(); i++) {
-            for (int j = 0; j < output.size(); j++) {
-              RealTestUtils.assertEqual(expected.getRow(i), output.get(j).getRow(i), 15);
-            }
-          }
-        }
-      };
+      DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix, 1);
+      DRes<Vector<DRes<SReal>>> closedVector = root.realLinAlg().input(vector, 1);
+      DRes<Vector<DRes<SReal>>> res1 =
+              root.realLinAlg().vectorMult(closedMatrix, closedVector);
+      DRes<Vector<DRes<SReal>>> res2 = root.realLinAlg().vectorMult(matrix, closedVector);
+      DRes<Vector<DRes<SReal>>> res3 = root.realLinAlg().vectorMult(closedMatrix, vector);
+      DRes<Vector<DRes<BigDecimal>>> open1 = root.realLinAlg().openVector(res1);
+      DRes<Vector<DRes<BigDecimal>>> open2 = root.realLinAlg().openVector(res2);
+      DRes<Vector<DRes<BigDecimal>>> open3 = root.realLinAlg().openVector(res3);
+      return () -> Arrays.asList(
+              open1.out().stream().map(x -> x.out())
+                      .collect(Collectors.toCollection(Vector::new)),
+              open2.out().stream().map(x -> x.out())
+                      .collect(Collectors.toCollection(Vector::new)),
+              open3.out().stream().map(x -> x.out())
+                      .collect(Collectors.toCollection(Vector::new)));
+    }, 2);
+    for (int i = 0; i < matrix.getHeight(); i++) {
+      for (int j = 0; j < output.size(); j++) {
+        RealTestUtils.assertEqual(expected.get(i), output.get(j).get(i), 15);
+      }
     }
   }
 
-  public static class TestMatrixOperate<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test(expected=IllegalArgumentException.class)
+  public void testVectorMultUnmatchedDimensions() {
+    final int dimension = 10;
+    final int precision = 4;
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        final int dimension = 50;
-        final int precision = 4;
-
-        @Override
-        public void test() throws Exception {
-          Matrix<BigDecimal> matrix = allOneMatrix(dimension, dimension, precision);
-          Vector<BigDecimal> vector = allOneVector(dimension, precision);
-          Vector<BigDecimal> expected = new Vector<>(dimension);
-          for (int i = 0; i < dimension; i++) {
-            expected.add(BigDecimal.valueOf(dimension).setScale(1));
-          }
-          Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
-
-            DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix, 1);
-            DRes<Vector<DRes<SReal>>> closedVector = root.realLinAlg().input(vector, 1);
-            DRes<Vector<DRes<SReal>>> res1 =
-                root.realLinAlg().vectorMult(closedMatrix, closedVector);
-            DRes<Vector<DRes<SReal>>> res2 = root.realLinAlg().vectorMult(matrix, closedVector);
-            DRes<Vector<DRes<SReal>>> res3 = root.realLinAlg().vectorMult(closedMatrix, vector);
-            DRes<Vector<DRes<BigDecimal>>> open1 = root.realLinAlg().openVector(res1);
-            DRes<Vector<DRes<BigDecimal>>> open2 = root.realLinAlg().openVector(res2);
-            DRes<Vector<DRes<BigDecimal>>> open3 = root.realLinAlg().openVector(res3);
-            return () -> Arrays.asList(
-                open1.out().stream().map(x -> x.out())
-                    .collect(Collectors.toCollection(Vector::new)),
-                open2.out().stream().map(x -> x.out())
-                    .collect(Collectors.toCollection(Vector::new)),
-                open3.out().stream().map(x -> x.out())
-                    .collect(Collectors.toCollection(Vector::new)));
-          };
-          List<Vector<BigDecimal>> output = runApplication(testApplication);
-          for (int i = 0; i < matrix.getHeight(); i++) {
-            for (int j = 0; j < output.size(); j++) {
-              RealTestUtils.assertEqual(expected.get(i), output.get(j).get(i), 15);
-            }
-          }
-        }
-      };
-    }
+    Matrix<BigDecimal> matrix = allOneMatrix(dimension, dimension, precision);
+    Vector<BigDecimal> vector = allOneVector(dimension - 1, precision);
+    Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
+      DRes<Vector<DRes<SReal>>> closedVector = root.realLinAlg().input(vector, 1);
+      root.realLinAlg().vectorMult(matrix, closedVector);
+      return () -> null;
+    };
+    run(testApplication);
   }
 
-  public static class TestVectorMultUnmatchedDimensions<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test(expected=IllegalArgumentException.class)
+  public void testAdditionUnmatchedHeight() {
+    final int dimension = 10;
+    final int precision = 4;
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        final int dimension = 10;
-        final int precision = 4;
-
-        @Override
-        public void test() throws Exception {
-          Matrix<BigDecimal> matrix = allOneMatrix(dimension, dimension, precision);
-          Vector<BigDecimal> vector = allOneVector(dimension - 1, precision);
-          Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Vector<DRes<SReal>>> closedVector = root.realLinAlg().input(vector, 1);
-            root.realLinAlg().vectorMult(matrix, closedVector);
-            return () -> null;
-          };
-          try {
-            runApplication(testApplication);
-            fail("Expected IllegalArgumentException");
-          } catch (RuntimeException e) {
-            if (e.getCause().getClass() != IllegalArgumentException.class) {
-              throw e;
-            }
-          }
-        }
-      };
-    }
+    Matrix<BigDecimal> matrix1 = allOneMatrix(dimension, dimension, precision);
+    Matrix<BigDecimal> matrix2 = allOneMatrix(dimension - 1, dimension, precision);
+    run((Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric>) root -> {
+      DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix1, 1);
+      root.realLinAlg().add(matrix2, closedMatrix);
+      return () -> null;
+    });
   }
 
-  public static class TestAdditionUnmatchedDimensions<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test(expected=IllegalArgumentException.class)
+  public void testAdditionUnmatchedWidth() {
+    final int dimension = 10;
+    final int precision = 4;
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        final int dimension = 10;
-        final int precision = 4;
-
-        @Override
-        public void test() throws Exception {
-          Matrix<BigDecimal> matrix1 = allOneMatrix(dimension, dimension, precision);
-          Matrix<BigDecimal> matrix2 = allOneMatrix(dimension - 1, dimension, precision);
-          Matrix<BigDecimal> matrix3 = allOneMatrix(dimension, dimension - 1, precision);
-          Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric> testApplication1 = root -> {
-            DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix1, 1);
-            root.realLinAlg().add(matrix2, closedMatrix);
-            return () -> null;
-          };
-          try {
-            runApplication(testApplication1);
-            fail("Expected IllegalArgumentException");
-          } catch (RuntimeException e) {
-            if (e.getCause().getClass() != IllegalArgumentException.class) {
-              throw e;
-            } else {
-              // Success - Ignore the exception
-            }
-          }
-          Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric> testApplication2 = root -> {
-            DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix1, 1);
-            root.realLinAlg().add(matrix3, closedMatrix);
-            return () -> null;
-          };
-          try {
-            runApplication(testApplication2);
-            fail("Expected IllegalArgumentException");
-          } catch (RuntimeException e) {
-            if (e.getCause().getClass() != IllegalArgumentException.class) {
-              throw e;
-            } else {
-              // Success - Ignore the exception
-            }
-          }
-        }
-      };
-    }
+    Matrix<BigDecimal> matrix1 = allOneMatrix(dimension, dimension, precision);
+    Matrix<BigDecimal> matrix3 = allOneMatrix(dimension, dimension - 1, precision);
+    run((Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric>) root -> {
+      DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix1, 1);
+      root.realLinAlg().add(matrix3, closedMatrix);
+      return () -> null;
+    });
   }
 
-  public static class TestMatrixMultUnmatchedDimensions<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test(expected=IllegalArgumentException.class)
+  public void testMatrixMultUnmatchedDimensions() {
+    final int dimension = 10;
+    final int precision = 4;
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        final int dimension = 10;
-        final int precision = 4;
-
-        @Override
-        public void test() throws Exception {
-          Matrix<BigDecimal> matrix1 = allOneMatrix(dimension, dimension, precision);
-          Matrix<BigDecimal> matrix2 = allOneMatrix(dimension, dimension - 1, precision);
-          Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric> testApplication1 = root -> {
-            DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix1, 1);
-            root.realLinAlg().mult(matrix2, closedMatrix);
-            return () -> null;
-          };
-          try {
-            runApplication(testApplication1);
-            fail("Expected IllegalArgumentException");
-          } catch (RuntimeException e) {
-            if (e.getCause().getClass() != IllegalArgumentException.class) {
-              throw e;
-            } else {
-              // Success - Ignore the exception
-            }
-          }
-        }
-      };
-    }
+    Matrix<BigDecimal> matrix1 = allOneMatrix(dimension, dimension, precision);
+    Matrix<BigDecimal> matrix2 = allOneMatrix(dimension, dimension - 1, precision);
+    run((Application<List<Vector<BigDecimal>>, ProtocolBuilderNumeric>) root -> {
+      DRes<Matrix<DRes<SReal>>> closedMatrix = root.realLinAlg().input(matrix1, 1);
+      root.realLinAlg().mult(matrix2, closedMatrix);
+      return () -> null;
+    });
   }
 
-  public static class TestTransposeMatrix<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
+  @Test
+  public void testTransposeMatrix() {
+    // define input and output
+    ArrayList<BigDecimal> rowOne = new ArrayList<>();
+    rowOne.add(BigDecimal.valueOf(1.1));
+    rowOne.add(BigDecimal.valueOf(2.2));
+    ArrayList<BigDecimal> rowTwo = new ArrayList<>();
+    rowTwo.add(BigDecimal.valueOf(3.3));
+    rowTwo.add(BigDecimal.valueOf(4.4));
+    ArrayList<BigDecimal> rowThree = new ArrayList<>();
+    rowThree.add(BigDecimal.valueOf(5.5));
+    rowThree.add(BigDecimal.valueOf(6.6));
+    ArrayList<ArrayList<BigDecimal>> mat = new ArrayList<>();
+    mat.add(rowOne);
+    mat.add(rowTwo);
+    mat.add(rowThree);
+    Matrix<BigDecimal> input = new Matrix<>(3, 2, mat);
 
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-
-        @Override
-        public void test() throws Exception {
-          // define input and output
-          ArrayList<BigDecimal> rowOne = new ArrayList<>();
-          rowOne.add(BigDecimal.valueOf(1.1));
-          rowOne.add(BigDecimal.valueOf(2.2));
-          ArrayList<BigDecimal> rowTwo = new ArrayList<>();
-          rowTwo.add(BigDecimal.valueOf(3.3));
-          rowTwo.add(BigDecimal.valueOf(4.4));
-          ArrayList<BigDecimal> rowThree = new ArrayList<>();
-          rowThree.add(BigDecimal.valueOf(5.5));
-          rowThree.add(BigDecimal.valueOf(6.6));
-          ArrayList<ArrayList<BigDecimal>> mat = new ArrayList<>();
-          mat.add(rowOne);
-          mat.add(rowTwo);
-          mat.add(rowThree);
-          Matrix<BigDecimal> input = new Matrix<>(3, 2, mat);
-
-          // define functionality to be tested
-          Application<Matrix<BigDecimal>, ProtocolBuilderNumeric> testApplication = root -> {
-            DRes<Matrix<DRes<SReal>>> closed = root.realLinAlg().input(input, 1);
-            DRes<Matrix<DRes<SReal>>> transposed = root.realLinAlg().transpose(closed);
-            DRes<Matrix<DRes<BigDecimal>>> opened = root.realLinAlg().openMatrix(transposed);
-            return () -> new MatrixUtils().unwrapMatrix(opened);
-          };
-          Matrix<BigDecimal> output = runApplication(testApplication);
-          System.out.println(output);
-          for (int i = 0; i < input.getHeight(); i++) {
-            RealTestUtils.assertEqual(output.getColumn(i), input.getRow(i), 15);
-          }
-        }
-      };
+    // define functionality to be tested
+    Application<Matrix<BigDecimal>, ProtocolBuilderNumeric> testApplication = root -> {
+      DRes<Matrix<DRes<SReal>>> closed = root.realLinAlg().input(input, 1);
+      DRes<Matrix<DRes<SReal>>> transposed = root.realLinAlg().transpose(closed);
+      DRes<Matrix<DRes<BigDecimal>>> opened = root.realLinAlg().openMatrix(transposed);
+      return () -> new MatrixUtils().unwrapMatrix(opened);
+    };
+    Matrix<BigDecimal> output = run(testApplication);
+    System.out.println(output);
+    for (int i = 0; i < input.getHeight(); i++) {
+      RealTestUtils.assertEqual(output.getColumn(i), input.getRow(i), 15);
     }
   }
-
 
   private static Vector<BigDecimal> allOneVector(int dimension, int precision) {
     Vector<BigDecimal> vector = new Vector<>(dimension);

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticRunner.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticRunner.java
@@ -1,0 +1,61 @@
+package dk.alexandra.fresco.suite.dummy.arithmetic;
+
+import dk.alexandra.fresco.framework.Application;
+import dk.alexandra.fresco.framework.TestFrameworkException;
+import dk.alexandra.fresco.framework.TestThreadRunner;
+import dk.alexandra.fresco.framework.builder.numeric.ProtocolBuilderNumeric;
+import dk.alexandra.fresco.suite.dummy.arithmetic.AbstractDummyArithmeticTest;
+import dk.alexandra.fresco.suite.dummy.arithmetic.DummyArithmeticResourcePool;
+
+import static dk.alexandra.fresco.framework.sce.evaluator.EvaluationStrategy.SEQUENTIAL;
+
+public class DummyArithmeticRunner {
+    static public <T> T run(Application<T, ProtocolBuilderNumeric> application) {
+        return run(application, 1);
+    }
+
+    static public <T> T run(Application<T, ProtocolBuilderNumeric> application, int numberOfParties) {
+        try {
+            // run application inside test framework
+            return new TestFramework<T>(numberOfParties).run(application);
+        } catch (TestFrameworkException exception) {
+            // strip test framework exceptions to get to the actual exception
+            if (exception.getCause().getCause() instanceof RuntimeException) {
+                throw (RuntimeException) exception.getCause().getCause();
+            } else if (exception.getCause().getCause() instanceof Error) {
+                throw (Error)exception.getCause().getCause();
+            } else {
+                throw exception;
+            }
+        }
+    }
+
+    private static class TestFramework<T> extends AbstractDummyArithmeticTest {
+        private int numberOfParties;
+
+        private TestFramework(int numberOfParties) {
+            this.numberOfParties = numberOfParties;
+        }
+
+        private T run(Application<T, ProtocolBuilderNumeric> application) {
+            Reference<T> output = new Reference<>();
+            runTest(new TestThreadRunner.TestThreadFactory<DummyArithmeticResourcePool, ProtocolBuilderNumeric>() {
+                @Override
+                public TestThreadRunner.TestThread<DummyArithmeticResourcePool, ProtocolBuilderNumeric> next() {
+                    return new TestThreadRunner.TestThread<DummyArithmeticResourcePool, ProtocolBuilderNumeric>() {
+                        @Override
+                        public void test() {
+                            output.value = runApplication(application);
+                        }
+                    };
+                }
+            }, SEQUENTIAL, numberOfParties);
+            return output.value;
+        }
+    }
+
+    private static class Reference<T> {
+        T value;
+    }
+}
+

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -40,7 +40,6 @@ import dk.alexandra.fresco.lib.math.integer.sqrt.SqrtTests;
 import dk.alexandra.fresco.lib.math.integer.stat.StatisticsTests;
 import dk.alexandra.fresco.lib.math.polynomial.PolynomialTests;
 import dk.alexandra.fresco.lib.real.BasicFixedPointTests;
-import dk.alexandra.fresco.lib.real.LinearAlgebraTests;
 import dk.alexandra.fresco.lib.real.MathTests;
 import dk.alexandra.fresco.lib.real.TruncationTests;
 import dk.alexandra.fresco.lib.statistics.CreditRaterTest;

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -680,66 +680,6 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   }
 
   @Test
-  public void test_Close_Real_Matrix() {
-    runTest(new LinearAlgebraTests.TestCloseFixedMatrix<>(), new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Close_And_Open_Real_Matrix() {
-    runTest(new LinearAlgebraTests.TestCloseAndOpenMatrix<>(), new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Real_Matrix_Addition() {
-    runTest(new LinearAlgebraTests.TestMatrixAddition<>(), new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Real_Matrix_Subtraction() {
-    runTest(new LinearAlgebraTests.TestMatrixSubtraction<>(), new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Real_Matrix_Multiplication() {
-    runTest(new LinearAlgebraTests.TestMatrixMultiplication<>(),
-        new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Real_Matrix_Scale() {
-    runTest(new LinearAlgebraTests.TestMatrixScale<>(), new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Real_Matrix_Operate() {
-    runTest(new LinearAlgebraTests.TestMatrixOperate<>(), new TestParameters().numParties(2));
-  }
-
-  @Test
-  public void test_Real_Vector_Multiplication_Unmatched() {
-    runTest(new LinearAlgebraTests.TestVectorMultUnmatchedDimensions<>(),
-        new TestParameters());
-  }
-
-  @Test
-  public void test_Real_Matrix_Multiplication_Unmatched() {
-    runTest(new LinearAlgebraTests.TestMatrixMultUnmatchedDimensions<>(),
-        new TestParameters());
-  }
-
-  @Test
-  public void test_Real_Matrix_Addition_Unmatched() {
-    runTest(new LinearAlgebraTests.TestAdditionUnmatchedDimensions<>(),
-        new TestParameters());
-  }
-
-  @Test
-  public void test_Real_Matrix_Transpose() {
-    runTest(new LinearAlgebraTests.TestTransposeMatrix<>(),
-        new TestParameters());
-  }
-
-  @Test
   public void test_Real_Exp() {
     runTest(new MathTests.TestExp<>(), new TestParameters().numParties(2));
   }


### PR DESCRIPTION
This introduces a DummyArithmeticRunner. It has a static run() method to run an application with dummy arithmetic.

We use this to remove about 200 lines of boilerplate code from the LinearAlgebraTests.