### PR TITLE
Fixing infinite recursion issue with OddEvenMerge when input size is …

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/lib/collections/sort/OddEvenMerge.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/collections/sort/OddEvenMerge.java
@@ -86,10 +86,12 @@ public class OddEvenMerge implements
       builder.seq((seq) -> {
         merge(first, length, doubleStep, seq);
         merge(first + step, length, doubleStep, seq);
-        for (int idx = first + step; idx + step < first + length; idx += doubleStep) {
-          compareAndSwapAtIndices(idx, idx + step, seq);
-        }
-        return null;
+        return seq.par(par -> {
+          for (int idx = first + step; idx + step < first + length; idx += doubleStep) {
+            compareAndSwapAtIndices(idx, idx + step, par);
+          }
+          return null;
+        });
       });
     } else {
       compareAndSwapAtIndices(first, first + step, builder);

--- a/core/src/main/java/dk/alexandra/fresco/lib/collections/sort/OddEvenMerge.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/collections/sort/OddEvenMerge.java
@@ -8,17 +8,17 @@ import dk.alexandra.fresco.framework.value.SBool;
 import java.util.List;
 
 /**
- * An implementation of the OddEvenMergeSortProtocol.
- * We use Batcher's algorithm to sort a list of boolean key/value pairs in descending order.
- * This sorting algorithm runs in O(n(log(n))^2) time.
+ * An implementation of the OddEvenMergeSortProtocol. We use Batcher's algorithm to sort a list of
+ * boolean key/value pairs in descending order. This sorting algorithm runs in O(n(log(n))^2) time.
  *
- * You can set the mergePresortedHalves flag to `true` to merge a list where the sequence of the first n / 2 elements
- * is sorted in descending order and the sequence of the remaining n / 2 elements is also sorted in descending order.
- * The protocol can then "merge" the two presorted halves into a (descending order) sorted list in O(nlog(n)) time.
- * Note, it is not currently known whether it is possible to obliviously merge two lists in O(n) time.
+ * You can set the mergePresortedHalves flag to `true` to merge a list where the sequence of the
+ * first n / 2 elements is sorted in descending order and the sequence of the remaining n / 2
+ * elements is also sorted in descending order. The protocol can then "merge" the two presorted
+ * halves into a (descending order) sorted list in O(nlog(n)) time. Note, it is not currently known
+ * whether it is possible to obliviously merge two lists in O(n) time.
  *
- * For now, this implementation only supports lists where the size is a power of 2 (i.e., 4, 8, 16, etc.).
- *
+ * For now, this implementation only supports lists where the size is a power of 2 (i.e., 4, 8, 16,
+ * etc.).
  */
 public class OddEvenMerge implements
     Computation<List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>>, ProtocolBuilderBinary> {
@@ -26,15 +26,15 @@ public class OddEvenMerge implements
   private List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> numbers;
   private boolean mergePresortedHalves = false;
 
-  public OddEvenMerge(
+  OddEvenMerge(
       List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unsortedNumbers) {
     super();
     this.numbers = unsortedNumbers;
   }
 
-  public OddEvenMerge(
-          List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unsortedNumbers,
-          boolean mergePresortedHalves) {
+  OddEvenMerge(
+      List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unsortedNumbers,
+      boolean mergePresortedHalves) {
     super();
     this.numbers = unsortedNumbers;
     this.mergePresortedHalves = mergePresortedHalves;
@@ -62,13 +62,12 @@ public class OddEvenMerge implements
   }
 
   private void compareAndSwapAtIndices(int i, int j, ProtocolBuilderBinary builder) {
-    builder.seq(seq -> {
-      return seq.advancedBinary().keyedCompareAndSwap(numbers.get(i), numbers.get(j));
-    }).seq((seq, res) -> {
-      numbers.set(i, res.get(0));
-      numbers.set(j, res.get(1));
-      return null;
-    });
+    builder.seq(seq -> seq.advancedBinary().keyedCompareAndSwap(numbers.get(i), numbers.get(j)))
+        .seq((seq, res) -> {
+          numbers.set(i, res.get(0));
+          numbers.set(j, res.get(1));
+          return null;
+        });
   }
 
   private void merge(int first, int length, int step, ProtocolBuilderBinary builder) {

--- a/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
@@ -198,6 +198,7 @@ public class CollectionsSortingTests {
                   toSort.add(new Pair<>(l61, l62));
                   toSort.add(new Pair<>(l81, l82));
                   toSort.add(new Pair<>(l51, l52));
+                  return seq.seq(new OddEvenMerge(toSort, presorted));
                 } else {
                   toSort.add(new Pair<>(l11, l12));
                   toSort.add(new Pair<>(l21, l22));
@@ -207,9 +208,9 @@ public class CollectionsSortingTests {
                   toSort.add(new Pair<>(l61, l62));
                   toSort.add(new Pair<>(l71, l72));
                   toSort.add(new Pair<>(l81, l82));
+                  // make code-cov happy
+                  return seq.seq(new OddEvenMerge(toSort));
                 }
-
-                return seq.seq(new OddEvenMerge(toSort, presorted));
               }).seq((seq, sorted) -> {
                 Binary builder = seq.binary();
                 List<Pair<List<DRes<Boolean>>, List<DRes<Boolean>>>> opened = new ArrayList<>();

--- a/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
@@ -124,7 +124,17 @@ public class CollectionsSortingTests {
           Boolean[] left41 = ByteAndBitConverter.toBoolean("02");
           Boolean[] left42 = ByteAndBitConverter.toBoolean("05");
 
-          Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary> app =
+          Boolean[] left51 = ByteAndBitConverter.toBoolean("11");
+          Boolean[] left52 = ByteAndBitConverter.toBoolean("10");
+          Boolean[] left61 = ByteAndBitConverter.toBoolean("13");
+          Boolean[] left62 = ByteAndBitConverter.toBoolean("17");
+          Boolean[] left71 = ByteAndBitConverter.toBoolean("19");
+          Boolean[] left72 = ByteAndBitConverter.toBoolean("16");
+          Boolean[] left81 = ByteAndBitConverter.toBoolean("12");
+          Boolean[] left82 = ByteAndBitConverter.toBoolean("15");
+
+          // Test sorting without using the mergePresortedHalves flag
+          Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary> appSort =
               new Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary>() {
 
             @Override
@@ -144,11 +154,27 @@ public class CollectionsSortingTests {
                     Arrays.asList(left31).stream().map(builder::known).collect(Collectors.toList());
                 List<DRes<SBool>> l32 =
                     Arrays.asList(left32).stream().map(builder::known).collect(Collectors.toList());
-
                 List<DRes<SBool>> l41 =
                     Arrays.asList(left41).stream().map(builder::known).collect(Collectors.toList());
                 List<DRes<SBool>> l42 =
                     Arrays.asList(left42).stream().map(builder::known).collect(Collectors.toList());
+
+                List<DRes<SBool>> l51 =
+                    Arrays.asList(left51).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l52 =
+                    Arrays.asList(left52).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l61 =
+                    Arrays.asList(left61).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l62 =
+                    Arrays.asList(left62).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l71 =
+                    Arrays.asList(left71).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l72 =
+                    Arrays.asList(left72).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l81 =
+                    Arrays.asList(left81).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l82 =
+                    Arrays.asList(left82).stream().map(builder::known).collect(Collectors.toList());
 
                 List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unSorted = new ArrayList<>();
 
@@ -156,6 +182,11 @@ public class CollectionsSortingTests {
                 unSorted.add(new Pair<>(l21, l22));
                 unSorted.add(new Pair<>(l31, l32));
                 unSorted.add(new Pair<>(l41, l42));
+                unSorted.add(new Pair<>(l51, l52));
+                unSorted.add(new Pair<>(l61, l62));
+                unSorted.add(new Pair<>(l71, l72));
+                unSorted.add(new Pair<>(l81, l82));
+
 
                 DRes<List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>>> sorted =
                     new OddEvenMerge(unSorted).buildComputation(seq);
@@ -188,16 +219,132 @@ public class CollectionsSortingTests {
 
           };
 
-          List<Pair<List<Boolean>, List<Boolean>>> results = runApplication(app);
+          List<Pair<List<Boolean>, List<Boolean>>> resultsSort = runApplication(appSort);
 
-          Assert.assertEquals(Arrays.asList(left21), results.get(0).getFirst());
-          Assert.assertEquals(Arrays.asList(left22), results.get(0).getSecond());
-          Assert.assertEquals(Arrays.asList(left41), results.get(1).getFirst());
-          Assert.assertEquals(Arrays.asList(left42), results.get(1).getSecond());
-          Assert.assertEquals(Arrays.asList(left11), results.get(2).getFirst());
-          Assert.assertEquals(Arrays.asList(left12), results.get(2).getSecond());
-          Assert.assertEquals(Arrays.asList(left31), results.get(3).getFirst());
-          Assert.assertEquals(Arrays.asList(left32), results.get(3).getSecond());
+          Assert.assertEquals(Arrays.asList(left71), resultsSort.get(0).getFirst());
+          Assert.assertEquals(Arrays.asList(left72), resultsSort.get(0).getSecond());
+          Assert.assertEquals(Arrays.asList(left61), resultsSort.get(1).getFirst());
+          Assert.assertEquals(Arrays.asList(left62), resultsSort.get(1).getSecond());
+          Assert.assertEquals(Arrays.asList(left81), resultsSort.get(2).getFirst());
+          Assert.assertEquals(Arrays.asList(left82), resultsSort.get(2).getSecond());
+          Assert.assertEquals(Arrays.asList(left51), resultsSort.get(3).getFirst());
+          Assert.assertEquals(Arrays.asList(left52), resultsSort.get(3).getSecond());
+
+          Assert.assertEquals(Arrays.asList(left21), resultsSort.get(4).getFirst());
+          Assert.assertEquals(Arrays.asList(left22), resultsSort.get(4).getSecond());
+          Assert.assertEquals(Arrays.asList(left41), resultsSort.get(5).getFirst());
+          Assert.assertEquals(Arrays.asList(left42), resultsSort.get(5).getSecond());
+          Assert.assertEquals(Arrays.asList(left11), resultsSort.get(6).getFirst());
+          Assert.assertEquals(Arrays.asList(left12), resultsSort.get(6).getSecond());
+          Assert.assertEquals(Arrays.asList(left31), resultsSort.get(7).getFirst());
+          Assert.assertEquals(Arrays.asList(left32), resultsSort.get(7).getSecond());
+
+
+          // Test using the mergePresortedHalves flag
+          Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary> appMergeOnly =
+              new Application<List<Pair<List<Boolean>, List<Boolean>>>, ProtocolBuilderBinary>() {
+            @Override
+            public DRes<List<Pair<List<Boolean>, List<Boolean>>>> buildComputation(
+                    ProtocolBuilderBinary producer) {
+              return producer.seq(seq -> {
+                Binary builder = seq.binary();
+                List<DRes<SBool>> l11 =
+                        Arrays.asList(left11).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l12 =
+                        Arrays.asList(left12).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l21 =
+                        Arrays.asList(left21).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l22 =
+                        Arrays.asList(left22).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l31 =
+                        Arrays.asList(left31).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l32 =
+                        Arrays.asList(left32).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l41 =
+                        Arrays.asList(left41).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l42 =
+                        Arrays.asList(left42).stream().map(builder::known).collect(Collectors.toList());
+
+                List<DRes<SBool>> l51 =
+                        Arrays.asList(left51).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l52 =
+                        Arrays.asList(left52).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l61 =
+                        Arrays.asList(left61).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l62 =
+                        Arrays.asList(left62).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l71 =
+                        Arrays.asList(left71).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l72 =
+                        Arrays.asList(left72).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l81 =
+                        Arrays.asList(left81).stream().map(builder::known).collect(Collectors.toList());
+                List<DRes<SBool>> l82 =
+                        Arrays.asList(left82).stream().map(builder::known).collect(Collectors.toList());
+
+                List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>> unSorted = new ArrayList<>();
+                
+                // Keep in mind that the first n / 2 keys need to be sorted, as do the second n / 2 keys.
+                // With the way comparisons work currently, we need the two halves to be sorted in descending order.
+                unSorted.add(new Pair<>(l21, l22));
+                unSorted.add(new Pair<>(l41, l42));
+                unSorted.add(new Pair<>(l11, l12));
+                unSorted.add(new Pair<>(l31, l32));
+                unSorted.add(new Pair<>(l71, l72));
+                unSorted.add(new Pair<>(l61, l62));
+                unSorted.add(new Pair<>(l81, l82));
+                unSorted.add(new Pair<>(l51, l52));
+
+                DRes<List<Pair<List<DRes<SBool>>, List<DRes<SBool>>>>> sorted =
+                        new OddEvenMerge(unSorted, true).buildComputation(seq);
+                return sorted;
+              }).seq((seq, sorted) -> {
+                Binary builder = seq.binary();
+                List<Pair<List<DRes<Boolean>>, List<DRes<Boolean>>>> opened = new ArrayList<>();
+                for (Pair<List<DRes<SBool>>, List<DRes<SBool>>> p : sorted) {
+                  List<DRes<Boolean>> oKeys = new ArrayList<>();
+                  for (DRes<SBool> key : p.getFirst()) {
+                    oKeys.add(builder.open(key));
+                  }
+                  List<DRes<Boolean>> oValues = new ArrayList<>();
+                  for (DRes<SBool> value : p.getSecond()) {
+                    oValues.add(builder.open(value));
+                  }
+                  opened.add(new Pair<>(oKeys, oValues));
+                }
+                return () -> opened;
+              }).seq((seq, opened) -> {
+                return () -> opened.stream().map((p) -> {
+                  List<Boolean> key =
+                          p.getFirst().stream().map(DRes::out).collect(Collectors.toList());
+                  List<Boolean> value =
+                          p.getSecond().stream().map(DRes::out).collect(Collectors.toList());
+                  return new Pair<>(key, value);
+                }).collect(Collectors.toList());
+              });
+            }
+
+          };
+
+          List<Pair<List<Boolean>, List<Boolean>>> resultsMergeOnly = runApplication(appMergeOnly);
+
+          Assert.assertEquals(Arrays.asList(left71), resultsMergeOnly.get(0).getFirst());
+          Assert.assertEquals(Arrays.asList(left72), resultsMergeOnly.get(0).getSecond());
+          Assert.assertEquals(Arrays.asList(left61), resultsMergeOnly.get(1).getFirst());
+          Assert.assertEquals(Arrays.asList(left62), resultsMergeOnly.get(1).getSecond());
+          Assert.assertEquals(Arrays.asList(left81), resultsMergeOnly.get(2).getFirst());
+          Assert.assertEquals(Arrays.asList(left82), resultsMergeOnly.get(2).getSecond());
+          Assert.assertEquals(Arrays.asList(left51), resultsMergeOnly.get(3).getFirst());
+          Assert.assertEquals(Arrays.asList(left52), resultsMergeOnly.get(3).getSecond());
+
+          Assert.assertEquals(Arrays.asList(left21), resultsMergeOnly.get(4).getFirst());
+          Assert.assertEquals(Arrays.asList(left22), resultsMergeOnly.get(4).getSecond());
+          Assert.assertEquals(Arrays.asList(left41), resultsMergeOnly.get(5).getFirst());
+          Assert.assertEquals(Arrays.asList(left42), resultsMergeOnly.get(5).getSecond());
+          Assert.assertEquals(Arrays.asList(left11), resultsMergeOnly.get(6).getFirst());
+          Assert.assertEquals(Arrays.asList(left12), resultsMergeOnly.get(6).getSecond());
+          Assert.assertEquals(Arrays.asList(left31), resultsMergeOnly.get(7).getFirst());
+          Assert.assertEquals(Arrays.asList(left32), resultsMergeOnly.get(7).getSecond());
         }
       };
     }

--- a/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/collections/sort/CollectionsSortingTests.java
@@ -235,23 +235,29 @@ public class CollectionsSortingTests {
 
           List<Pair<List<Boolean>, List<Boolean>>> resultsMergeOnly = runApplication(app);
 
-          Assert.assertEquals(Arrays.asList(left71), resultsMergeOnly.get(0).getFirst());
-          Assert.assertEquals(Arrays.asList(left72), resultsMergeOnly.get(0).getSecond());
-          Assert.assertEquals(Arrays.asList(left61), resultsMergeOnly.get(1).getFirst());
-          Assert.assertEquals(Arrays.asList(left62), resultsMergeOnly.get(1).getSecond());
-          Assert.assertEquals(Arrays.asList(left81), resultsMergeOnly.get(2).getFirst());
-          Assert.assertEquals(Arrays.asList(left82), resultsMergeOnly.get(2).getSecond());
-          Assert.assertEquals(Arrays.asList(left51), resultsMergeOnly.get(3).getFirst());
-          Assert.assertEquals(Arrays.asList(left52), resultsMergeOnly.get(3).getSecond());
+          Assert.assertEquals("19", ByteAndBitConverter.toHex(resultsMergeOnly.get(0).getFirst()));
+          Assert.assertEquals("16", ByteAndBitConverter.toHex(resultsMergeOnly.get(0).getSecond()));
 
-          Assert.assertEquals(Arrays.asList(left21), resultsMergeOnly.get(4).getFirst());
-          Assert.assertEquals(Arrays.asList(left22), resultsMergeOnly.get(4).getSecond());
-          Assert.assertEquals(Arrays.asList(left41), resultsMergeOnly.get(5).getFirst());
-          Assert.assertEquals(Arrays.asList(left42), resultsMergeOnly.get(5).getSecond());
-          Assert.assertEquals(Arrays.asList(left11), resultsMergeOnly.get(6).getFirst());
-          Assert.assertEquals(Arrays.asList(left12), resultsMergeOnly.get(6).getSecond());
-          Assert.assertEquals(Arrays.asList(left31), resultsMergeOnly.get(7).getFirst());
-          Assert.assertEquals(Arrays.asList(left32), resultsMergeOnly.get(7).getSecond());
+          Assert.assertEquals("13", ByteAndBitConverter.toHex(resultsMergeOnly.get(1).getFirst()));
+          Assert.assertEquals("17", ByteAndBitConverter.toHex(resultsMergeOnly.get(1).getSecond()));
+
+          Assert.assertEquals("12", ByteAndBitConverter.toHex(resultsMergeOnly.get(2).getFirst()));
+          Assert.assertEquals("15", ByteAndBitConverter.toHex(resultsMergeOnly.get(2).getSecond()));
+
+          Assert.assertEquals("11", ByteAndBitConverter.toHex(resultsMergeOnly.get(3).getFirst()));
+          Assert.assertEquals("10", ByteAndBitConverter.toHex(resultsMergeOnly.get(3).getSecond()));
+
+          Assert.assertEquals("03", ByteAndBitConverter.toHex(resultsMergeOnly.get(4).getFirst()));
+          Assert.assertEquals("07", ByteAndBitConverter.toHex(resultsMergeOnly.get(4).getSecond()));
+
+          Assert.assertEquals("02", ByteAndBitConverter.toHex(resultsMergeOnly.get(5).getFirst()));
+          Assert.assertEquals("05", ByteAndBitConverter.toHex(resultsMergeOnly.get(5).getSecond()));
+
+          Assert.assertEquals("01", ByteAndBitConverter.toHex(resultsMergeOnly.get(6).getFirst()));
+          Assert.assertEquals("08", ByteAndBitConverter.toHex(resultsMergeOnly.get(6).getSecond()));
+
+          Assert.assertEquals("00", ByteAndBitConverter.toHex(resultsMergeOnly.get(7).getFirst()));
+          Assert.assertEquals("06", ByteAndBitConverter.toHex(resultsMergeOnly.get(7).getSecond()));
         }
       };
     }

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/bool/TestDummyProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/bool/TestDummyProtocolSuite.java
@@ -29,200 +29,210 @@ public class TestDummyProtocolSuite extends AbstractDummyBooleanTest {
 
   // Basic tests for boolean suites
   @Test
-  public void test_basic_logic() throws Exception {
-    runTest(new BasicBooleanTests.TestInput<>(true), EvaluationStrategy.SEQUENTIAL, true);
-    runTest(new BasicBooleanTests.TestInputDifferentSender<>(true), EvaluationStrategy.SEQUENTIAL, true, 2);
-    runTest(new BasicBooleanTests.TestXOR<>(true), EvaluationStrategy.SEQUENTIAL, true);
-    runTest(new BasicBooleanTests.TestAND<>(true), EvaluationStrategy.SEQUENTIAL, true);
-    runTest(new BasicBooleanTests.TestNOT<>(true), EvaluationStrategy.SEQUENTIAL, true);
-    runTest(new BasicBooleanTests.TestRandomBit<>(true), EvaluationStrategy.SEQUENTIAL, true);
-    
-    assertThat(performanceLoggers.get(1).get(2).getLoggedValues().get(BinaryLoggingDecorator.BINARY_BASIC_XOR), is((long)4));
-    assertThat(performanceLoggers.get(1).get(3).getLoggedValues().get(BinaryLoggingDecorator.BINARY_BASIC_AND), is((long)4));
-    assertThat(performanceLoggers.get(1).get(5).getLoggedValues().get(BinaryLoggingDecorator.BINARY_BASIC_RANDOM), is((long)1));
+  public void test_basic_logic() {
+    runTest(new BasicBooleanTests.TestInput<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED, true);
+    runTest(new BasicBooleanTests.TestInputDifferentSender<>(true),
+        EvaluationStrategy.SEQUENTIAL_BATCHED,
+        true, 2);
+    runTest(new BasicBooleanTests.TestXOR<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED, true);
+    runTest(new BasicBooleanTests.TestAND<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED, true);
+    runTest(new BasicBooleanTests.TestNOT<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED, true);
+    runTest(new BasicBooleanTests.TestRandomBit<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED,
+        true);
+
+    assertThat(performanceLoggers.get(1).get(2).getLoggedValues()
+        .get(BinaryLoggingDecorator.BINARY_BASIC_XOR), is((long) 4));
+    assertThat(performanceLoggers.get(1).get(3).getLoggedValues()
+        .get(BinaryLoggingDecorator.BINARY_BASIC_AND), is((long) 4));
+    assertThat(performanceLoggers.get(1).get(5).getLoggedValues()
+        .get(BinaryLoggingDecorator.BINARY_BASIC_RANDOM), is((long) 1));
   }
 
   // lib.field.bool.generic
   // Slightly more advanced protocols for lowlevel logic operations
   @Test
-  public void test_XNor() throws Exception {
+  public void test_XNor() {
     runTest(new FieldBoolTests.TestXNorFromXorAndNot<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
     runTest(new FieldBoolTests.TestXNorFromOpen<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_OR() throws Exception {
+  public void test_OR() {
     runTest(new FieldBoolTests.TestOrFromXorAnd<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
     runTest(new FieldBoolTests.TestOrFromCopyConst<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void testOpen() throws Exception {
+  public void testOpen() {
     runTest(new FieldBoolTests.TestOpen<>(), EvaluationStrategy.SEQUENTIAL_BATCHED, true);
-    assertThat(performanceLoggers.get(1).get(0).getLoggedValues().get(NetworkLoggingDecorator.NETWORK_TOTAL_BYTES), is((long)4));
+    assertThat(performanceLoggers.get(1).get(0).getLoggedValues()
+        .get(NetworkLoggingDecorator.NETWORK_TOTAL_BYTES), is((long) 4));
   }
 
   @Test
-  public void test_NAND() throws Exception {
+  public void test_NAND() {
     runTest(new FieldBoolTests.TestNandFromAndAndNot<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
     runTest(new FieldBoolTests.TestNandFromOpen<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_AndFromCopy() throws Exception {
+  public void test_AndFromCopy() {
     runTest(new FieldBoolTests.TestAndFromCopyConst<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   // lib.math.bool
   @Test
-  public void test_One_Bit_Half_Adder() throws Exception {
+  public void test_One_Bit_Half_Adder() {
     runTest(new AddTests.TestOnebitHalfAdder<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_One_Bit_Full_Adder() throws Exception {
+  public void test_One_Bit_Full_Adder() {
     runTest(new AddTests.TestOnebitFullAdder<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Binary_Adder() throws Exception {
+  public void test_Binary_Adder() {
     runTest(new AddTests.TestFullAdder<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Binary_BitIncrementAdder() throws Exception {
+  public void test_Binary_BitIncrementAdder() {
     runTest(new AddTests.TestBitIncrement<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Binary_Mult() throws Exception {
+  public void test_Binary_Mult() {
     runTest(new MultTests.TestBinaryMult<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   // Bristol tests
   @Test
-  public void test_Mult32x32_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.Mult32x32Test<>(true), EvaluationStrategy.SEQUENTIAL);
+  public void test_Mult32x32_Sequential() {
+    runTest(new BristolCryptoTests.Mult32x32Test<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_AES_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.AesTest<>(true), EvaluationStrategy.SEQUENTIAL);
-  }
-
-  @Test
-  public void test_AES_Multi_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.MultiAesTest<>(true), EvaluationStrategy.SEQUENTIAL);
-  }
-  
-  @Test
-  public void test_AES_SequentialBatched() throws Exception {
+  public void test_AES_Sequential() {
     runTest(new BristolCryptoTests.AesTest<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_DES_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.DesTest<>(true), EvaluationStrategy.SEQUENTIAL);
+  public void test_AES_Multi_Sequential() {
+    runTest(new BristolCryptoTests.MultiAesTest<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_MD5_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.MD5Test<>(true), EvaluationStrategy.SEQUENTIAL);
+  public void test_AES_SequentialBatched() {
+    runTest(new BristolCryptoTests.AesTest<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_SHA1_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.Sha1Test<>(true), EvaluationStrategy.SEQUENTIAL);
+  public void test_DES_Sequential() {
+    runTest(new BristolCryptoTests.DesTest<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_SHA256_Sequential() throws Exception {
-    runTest(new BristolCryptoTests.Sha256Test<>(true), EvaluationStrategy.SEQUENTIAL);
+  public void test_MD5_Sequential() {
+    runTest(new BristolCryptoTests.MD5Test<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Bristol_Errors_XOR() throws Exception {
-    runTest(new BadBristolCryptoTests.XorTest1<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.XorTest2<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.XorTest3<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.XorTest4<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.XorTest5<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_SHA1_Sequential() {
+    runTest(new BristolCryptoTests.Sha1Test<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Bristol_Errors_AND() throws Exception {
-    runTest(new BadBristolCryptoTests.AndTest1<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.AndTest2<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.AndTest3<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.AndTest4<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.AndTest5<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_SHA256_Sequential() {
+    runTest(new BristolCryptoTests.Sha256Test<>(true), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Bristol_Errors_INV() throws Exception {
-    runTest(new BadBristolCryptoTests.InvTest1<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.InvTest2<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.InvTest3<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.InvTest4<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_Bristol_Errors_XOR() {
+    runTest(new BadBristolCryptoTests.XorTest1<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.XorTest2<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.XorTest3<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.XorTest4<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.XorTest5<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Bristol_Errors_NOSUCHOPERATION() throws Exception {
-    runTest(new BadBristolCryptoTests.BadOperationTest<>(), EvaluationStrategy.SEQUENTIAL);
-    runTest(new BadBristolCryptoTests.NoCircuitTest<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_Bristol_Errors_AND() {
+    runTest(new BadBristolCryptoTests.AndTest1<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.AndTest2<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.AndTest3<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.AndTest4<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.AndTest5<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_basic_logic_all_in_one() throws Exception {
-    runTest(new BasicBooleanTests.TestBasicProtocols<>(true), EvaluationStrategy.SEQUENTIAL);
+  public void test_Bristol_Errors_INV() {
+    runTest(new BadBristolCryptoTests.InvTest1<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.InvTest2<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.InvTest3<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.InvTest4<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_comparison() throws Exception {
-    runTest(new ComparisonBooleanTests.TestGreaterThan<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_Bristol_Errors_NOSUCHOPERATION() {
+    runTest(new BadBristolCryptoTests.BadOperationTest<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+    runTest(new BadBristolCryptoTests.NoCircuitTest<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_comparison_unequal_length() throws Exception {
+  public void test_basic_logic_all_in_one() {
+    runTest(new BasicBooleanTests.TestBasicProtocols<>(true),
+        EvaluationStrategy.SEQUENTIAL_BATCHED);
+  }
+
+  @Test
+  public void test_comparison() {
+    runTest(new ComparisonBooleanTests.TestGreaterThan<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
+  }
+
+  @Test
+  public void test_comparison_unequal_length() {
     runTest(new ComparisonBooleanTests.TestGreaterThanUnequalLength<>(),
-        EvaluationStrategy.SEQUENTIAL);
+        EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_equality() throws Exception {
-    runTest(new ComparisonBooleanTests.TestEquality<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_equality() {
+    runTest(new ComparisonBooleanTests.TestEquality<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   // collections.sort
   @Test
-  public void test_Uneven_Odd_Even_Merge_2_parties() throws Exception {
-    runTest(new CollectionsSortingTests.TestOddEvenMerge<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_Uneven_Odd_Even_Merge_2_parties() {
+    runTest(new CollectionsSortingTests.TestOddEvenMerge<>(),
+        EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Keyed_Compare_And_Swap_2_parties() throws Exception {
-    runTest(new CollectionsSortingTests.TestKeyedCompareAndSwap<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_Keyed_Compare_And_Swap_2_parties() {
+    runTest(new CollectionsSortingTests.TestKeyedCompareAndSwap<>(),
+        EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Compare_And_Swap() throws Exception {
-    runTest(new CompareTests.CompareAndSwapTest<>(), EvaluationStrategy.SEQUENTIAL);
+  public void test_Compare_And_Swap() {
+    runTest(new CompareTests.CompareAndSwapTest<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
 
   @Test
-  public void test_Debug_Marker() throws Exception {
+  public void test_Debug_Marker() {
     runTest(new BinaryDebugTests.TestBinaryOpenAndPrint<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Debug_OpenAndPrintSysout() throws Exception {
+  public void test_Debug_OpenAndPrintSysout() {
     runTest(new BinaryDebugTests.TestBinaryDebugToNullStream<>(),
         EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 
   @Test
-  public void test_Binary_Log_Nice() throws Exception {
+  public void test_Binary_Log_Nice() {
     runTest(new LogTests.TestLogNice<>(), EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 }

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/bool/TestDummyProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/bool/TestDummyProtocolSuite.java
@@ -7,6 +7,7 @@ import dk.alexandra.fresco.framework.sce.evaluator.EvaluationStrategy;
 import dk.alexandra.fresco.lib.bool.BasicBooleanTests;
 import dk.alexandra.fresco.lib.bool.ComparisonBooleanTests;
 import dk.alexandra.fresco.lib.collections.sort.CollectionsSortingTests;
+import dk.alexandra.fresco.lib.collections.sort.CollectionsSortingTests.TestOddEvenMerge;
 import dk.alexandra.fresco.lib.compare.CompareTests;
 import dk.alexandra.fresco.lib.crypto.BadBristolCryptoTests;
 import dk.alexandra.fresco.lib.crypto.BristolCryptoTests;
@@ -202,9 +203,16 @@ public class TestDummyProtocolSuite extends AbstractDummyBooleanTest {
   }
 
   // collections.sort
+
   @Test
   public void test_Uneven_Odd_Even_Merge_2_parties() {
-    runTest(new CollectionsSortingTests.TestOddEvenMerge<>(),
+    runTest(new TestOddEvenMerge<>(false),
+        EvaluationStrategy.SEQUENTIAL_BATCHED);
+  }
+
+  @Test
+  public void test_Uneven_Odd_Even_Merge_presorted_2_parties() {
+    runTest(new TestOddEvenMerge<>(true),
         EvaluationStrategy.SEQUENTIAL_BATCHED);
   }
 


### PR DESCRIPTION
…greater than four.

Modifying TestOddEvenMerge to test sorting for input of size eight.

Adding a constructor for OddEvenMerge with the `mergePresortedHalves` flag to allow merging
a list with individually sorted halves into a fully sorted list.

Adding a test in TestOddEvenMerge for the `mergePresortedHalves` flag.