### PR TITLE
bump jacoco version to v0.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.1</version>
+				<version>0.8.3</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
fixes issues with running on newer JDKs,  
however requires Maven >= 3.0 (see https://github.com/jacoco/jacoco/releases).

if the Maven >= 3.0 is an issue then v0.8.2 could be used instead as it doesn't have that requirement yet.