### PR TITLE
configurable docker image for gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,7 @@
-image: registry.gitlab.com/partisia/dockerimages/maven-jdk9:latest
+variables:
+  DOCKER_IMAGE: registry.gitlab.com/partisia/dockerimages/maven-jdk9:latest
+
+image: $DOCKER_IMAGE
 
 run-test:
   stage: build


### PR DESCRIPTION
since `registry.gitlab.com/partisia/dockerimages/maven-jdk9:latest` is private this makes it very easy to override the `DOCKER_IMAGE` env var in gitlab and use an accessible image.