### PR TITLE
Simplify fixed point implementation

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/lib/real/AdvancedRealNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/real/AdvancedRealNumeric.java
@@ -51,10 +51,9 @@ public interface AdvancedRealNumeric extends ComputationDirectory {
    * sampled as <i>r * 2<sup>-n</sup></i> for a random positive <i>n</i> bit number <i>r</i>.
    * </p>
    *
-   * @param bits the number of random bits used for the sample
    * @return The random value
    */
-  DRes<SReal> random(int bits);
+  DRes<SReal> random();
 
   /**
    * Calculate the natural logarithm of a secret value. Works best for small inputs (< 10), so

--- a/core/src/main/java/dk/alexandra/fresco/lib/real/RealNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/real/RealNumeric.java
@@ -27,7 +27,18 @@ public interface RealNumeric extends ComputationDirectory {
    * @return A deferred result computing a+b
    */
   DRes<SReal> add(BigDecimal a, DRes<SReal> b);
-
+  
+  /**
+   * Adds a secret value with a public value and returns the result.
+   *
+   * @param a Public value
+   * @param b Secret value
+   * @return A deferred result computing a+b
+   */
+  default DRes<SReal> add(double a, DRes<SReal> b) {
+    return add(BigDecimal.valueOf(a), b);
+  }
+  
   /**
    * Subtracts two secret values and returns the result.
    *
@@ -47,6 +58,17 @@ public interface RealNumeric extends ComputationDirectory {
   DRes<SReal> sub(BigDecimal a, DRes<SReal> b);
 
   /**
+   * Subtracts a public value and a secret value and returns the result.
+   *
+   * @param a Public value
+   * @param b Secret value
+   * @return A deferred result computing a-b
+   */
+  default DRes<SReal> sub(double a, DRes<SReal> b) {
+    return sub(BigDecimal.valueOf(a), b);
+  }
+  
+  /**
    * Subtracts a secret value and a public value and returns the result.
    *
    * @param a Secret value
@@ -54,6 +76,17 @@ public interface RealNumeric extends ComputationDirectory {
    * @return A deferred result computing a-b
    */
   DRes<SReal> sub(DRes<SReal> a, BigDecimal b);
+
+  /**
+   * Subtracts a secret value and a public value and returns the result.
+   *
+   * @param a Secret value
+   * @param b Public value
+   * @return A deferred result computing a-b
+   */
+  default DRes<SReal> sub(DRes<SReal> a, double b) {
+    return sub(a, BigDecimal.valueOf(b));
+  }
 
   /**
    * Multiplies two secret values and returns the result.
@@ -74,6 +107,17 @@ public interface RealNumeric extends ComputationDirectory {
   DRes<SReal> mult(BigDecimal a, DRes<SReal> b);
 
   /**
+   * Multiplies a public value onto a secret value and returns the result.
+   *
+   * @param a Public value
+   * @param b Secret value
+   * @return A deferred result computing a*b
+   */
+  default DRes<SReal> mult(double a, DRes<SReal> b) {
+    return mult(BigDecimal.valueOf(a), b);
+  }
+
+  /**
    * Divides two secret values and returns the result.
    *
    * @param a Secret value 1
@@ -90,7 +134,18 @@ public interface RealNumeric extends ComputationDirectory {
    * @return A deferred result computing a/b
    */
   DRes<SReal> div(DRes<SReal> a, BigDecimal b);
-
+  
+  /**
+   * Divides a secret value with a public value and returns the result.
+   *
+   * @param a Secret value
+   * @param b Public value
+   * @return A deferred result computing a/b
+   */
+  default DRes<SReal> div(DRes<SReal> a, double b) {
+    return div(a, BigDecimal.valueOf(b));
+  }
+  
   /**
    * Creates a known secret value from a public value. This is primarily a helper function in order
    * to use public values within the FRESCO functions.
@@ -99,6 +154,17 @@ public interface RealNumeric extends ComputationDirectory {
    * @return A secret value which represents the given public value.
    */
   DRes<SReal> known(BigDecimal value);
+
+  /**
+   * Creates a known secret value from a public value. This is primarily a helper function in order
+   * to use public values within the FRESCO functions.
+   *
+   * @param value The public value.
+   * @return A secret value which represents the given public value.
+   */
+  default DRes<SReal> known(double value) {
+    return known(BigDecimal.valueOf(value));
+  }
 
   /**
    * Create a secret real value from a secret integer value representing the same value.
@@ -118,6 +184,18 @@ public interface RealNumeric extends ComputationDirectory {
    */
   DRes<SReal> input(BigDecimal value, int inputParty);
 
+  /**
+   * Closes a public value. If the MPC party calling this method is not providing input, just use
+   * null as the input value.
+   *
+   * @param value The value to input or null if no input should be given.
+   * @param inputParty The ID of the MPC party.
+   * @return The closed input value.
+   */
+  default DRes<SReal> input(double value, int inputParty) {
+    return input(BigDecimal.valueOf(value), inputParty);
+  }
+  
   /**
    * Opens a value to all MPC parties.
    *

--- a/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/AdvancedFixedNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/AdvancedFixedNumeric.java
@@ -6,7 +6,7 @@ import dk.alexandra.fresco.framework.builder.numeric.ProtocolBuilderNumeric;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.real.DefaultAdvancedRealNumeric;
 import dk.alexandra.fresco.lib.real.SReal;
-import java.math.BigDecimal;
+import java.math.BigInteger;
 
 public class AdvancedFixedNumeric extends DefaultAdvancedRealNumeric {
 
@@ -19,29 +19,26 @@ public class AdvancedFixedNumeric extends DefaultAdvancedRealNumeric {
     return builder.seq(seq -> {
       SFixed cast = (SFixed) x.out();
       DRes<SInt> underlyingInt = cast.getSInt();
-      int scale = cast.getPrecision();
+
       DRes<SInt> intResult =
           seq.advancedNumeric().sqrt(underlyingInt, seq.getBasicNumericContext().getMaxBitLength());
 
-      int newScale = Math.floorDiv(scale, 2);
-      DRes<SReal> result = new SFixed(intResult, newScale);
+      DRes<SInt> truncated = seq.numeric().mult(
+          BigInteger.ONE.shiftLeft(seq.getRealNumericContext().getPrecision() / 2), intResult);
 
-      int scaleResidue = Math.floorMod(scale, 2);
-      if (scaleResidue == 1) {
-        result = seq.realNumeric().mult(BigDecimal.valueOf(1.0 / Math.sqrt(2.0)), result);
-      }
-      return result;
+      return new SFixed(truncated);
     });
 
   }
 
   @Override
-  public DRes<SReal> random(int bits) {
+  public DRes<SReal> random() {
     return builder.seq(seq -> {
-      DRes<RandomAdditiveMask> random = seq.advancedNumeric().additiveMask(bits);
+      DRes<RandomAdditiveMask> random =
+          seq.advancedNumeric().additiveMask(seq.getRealNumericContext().getPrecision());
       return random;
     }).seq((seq, random) -> {
-      return () -> new SFixed(random.random, bits);
+      return () -> new SFixed(random.random);
     });
   }
 }

--- a/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/FixedNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/FixedNumeric.java
@@ -10,6 +10,7 @@ import dk.alexandra.fresco.lib.real.fixed.utils.Truncate;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.util.Objects;
 
 /**
  * An implementation of the {@link RealNumeric} ComputationDirectory based on a fixed point
@@ -27,9 +28,7 @@ public class FixedNumeric implements RealNumeric {
    *     the fixed point operations.
    */
   public FixedNumeric(ProtocolBuilderNumeric builder) {
-    if (builder == null) {
-      throw new NullPointerException();
-    }
+    Objects.requireNonNull(builder);
     this.builder = builder;
   }
 

--- a/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/FixedNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/FixedNumeric.java
@@ -10,7 +10,6 @@ import dk.alexandra.fresco.lib.real.fixed.utils.Truncate;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.Objects;
 
 /**
  * An implementation of the {@link RealNumeric} ComputationDirectory based on a fixed point
@@ -18,9 +17,7 @@ import java.util.Objects;
  */
 public class FixedNumeric implements RealNumeric {
 
-  private static final BigInteger BASE = BigInteger.valueOf(2);
-  private final int defaultPrecision;
-  private final int maxPrecision;
+  private static final BigInteger TWO = BigInteger.valueOf(2);
   private final ProtocolBuilderNumeric builder;
 
   /**
@@ -28,35 +25,25 @@ public class FixedNumeric implements RealNumeric {
    *
    * @param builder a ProtocolBuilder for the numeric computations which will be used to implement
    *     the fixed point operations.
-   * @param precision the precision used for the fixed point numbers. The precision must be in the
-   *     range <i>0 ... <code>builder.getMaxBitLength</code> / 4</i>.
    */
-  public FixedNumeric(ProtocolBuilderNumeric builder, int precision) {
-    this.builder = builder;
-    this.defaultPrecision = precision;
-    /*
-     * We reserve as many bits the integer part as for the fractional part and to be able to
-     * represent products, we need to be able to hold twice that under the max bit length.
-     */
-    Objects.requireNonNull(builder);
-    this.maxPrecision = builder.getBasicNumericContext().getMaxBitLength() / 4;
-    if (defaultPrecision < 0 || defaultPrecision > maxPrecision) {
-      throw new IllegalArgumentException(
-          "Precision must be in the range 0 ... " + maxPrecision + " but was " + defaultPrecision);
-    }
-  }
-
   public FixedNumeric(ProtocolBuilderNumeric builder) {
-    this(builder, builder.getRealNumericContext().getPrecision());
+    if (builder == null) {
+      throw new NullPointerException();
+    }
+    this.builder = builder;
   }
 
-  private BigInteger unscaled(BigDecimal value, int scale) {
-    return value.multiply(new BigDecimal(BASE.pow(scale))).setScale(0, RoundingMode.HALF_UP)
+  /**
+   * Return value * 2^{scale} rounded to the nearest integer, eg. the best integer for representing
+   * a given value as a fixed point in base two with the given precision.
+   * 
+   * @param value A decimal value.
+   * @param precision
+   * @return
+   */
+  private static BigInteger unscaled(BigDecimal value, int precision) {
+    return value.multiply(new BigDecimal(TWO.pow(precision))).setScale(0, RoundingMode.HALF_UP)
         .toBigIntegerExact();
-  }
-
-  private DRes<SInt> unscaled(ProtocolBuilderNumeric scope, SFixed value, int scale) {
-    return scale(scope, value.getSInt(), scale - value.getPrecision());
   }
 
   /**
@@ -67,12 +54,12 @@ public class FixedNumeric implements RealNumeric {
    * @param scale The scale
    * @return the value <i>unscaled * 2<sup>-scale</sup></i>.
    */
-  private BigDecimal scaled(
+  private static BigDecimal scaled(
       FieldDefinition fieldDefinition,
       BigInteger unscaled, int scale) {
     return new BigDecimal(fieldDefinition.convertToSigned(unscaled))
         .setScale(scale, RoundingMode.UNNECESSARY)
-        .divide(new BigDecimal(BASE.pow(scale)), RoundingMode.HALF_UP);
+        .divide(new BigDecimal(TWO.pow(scale)), RoundingMode.HALF_UP);
   }
 
   /**
@@ -96,185 +83,155 @@ public class FixedNumeric implements RealNumeric {
   @Override
   public DRes<SReal> add(DRes<SReal> a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      SFixed floatB = (SFixed) b.out();
-      int precision = Math.max(floatA.getPrecision(), (floatB.getPrecision()));
-      DRes<SInt> unscaledA = unscaled(seq, floatA, precision);
-      DRes<SInt> unscaledB = unscaled(seq, floatB, precision);
-      return new SFixed(seq.numeric().add(unscaledA, unscaledB), precision);
+      SFixed fixedA = (SFixed) a.out();
+      SFixed fixedB = (SFixed) b.out();
+      return new SFixed(seq.numeric().add(fixedA.getSInt(), fixedB.getSInt()));
     });
   }
 
   @Override
   public DRes<SReal> add(BigDecimal a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatB = (SFixed) b.out();
-      int precision = Math.max(defaultPrecision, floatB.getPrecision());
-      BigInteger intA = unscaled(a, precision);
-      DRes<SInt> unscaledB = unscaled(seq, (SFixed) b.out(), precision);
-      return new SFixed(seq.numeric().add(intA, unscaledB), precision);
+      BigInteger intA = unscaled(a, seq.getRealNumericContext().getPrecision());
+      SFixed fixedB = (SFixed) b.out();
+      return new SFixed(seq.numeric().add(intA, fixedB.getSInt()));
     });
   }
 
   @Override
   public DRes<SReal> sub(DRes<SReal> a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      SFixed floatB = (SFixed) b.out();
-      int precision = Math.max(floatA.getPrecision(), floatB.getPrecision());
-      DRes<SInt> unscaledA = unscaled(seq, floatA, precision);
-      DRes<SInt> unscaledB = unscaled(seq, floatB, precision);
-      return new SFixed(seq.numeric().sub(unscaledA, unscaledB), precision);
+      SFixed fixedA = (SFixed) a.out();
+      SFixed fixedB = (SFixed) b.out();
+      return new SFixed(seq.numeric().sub(fixedA.getSInt(), fixedB.getSInt()));
     });
   }
 
   @Override
   public DRes<SReal> sub(BigDecimal a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatB = (SFixed) b.out();
-      int precision = Math.max(defaultPrecision, floatB.getPrecision());
-      BigInteger scaledA = unscaled(a, precision);
-      DRes<SInt> unscaledB = unscaled(seq, floatB, precision);
-      return new SFixed(seq.numeric().sub(scaledA, unscaledB), precision);
+      BigInteger scaledA = unscaled(a, seq.getRealNumericContext().getPrecision());
+      SFixed fixedB = (SFixed) b.out();
+      return new SFixed(seq.numeric().sub(scaledA, fixedB.getSInt()));
     });
   }
 
   @Override
   public DRes<SReal> sub(DRes<SReal> a, BigDecimal b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      int precision = Math.max(defaultPrecision, floatA.getPrecision());
-      DRes<SInt> unscaledA = unscaled(seq, floatA, precision);
-      BigInteger unscaledB = unscaled(b, precision);
-      return new SFixed(seq.numeric().sub(unscaledA, unscaledB), precision);
+      SFixed fixedA = (SFixed) a.out();
+      BigInteger unscaledB = unscaled(b, seq.getRealNumericContext().getPrecision());
+      return new SFixed(seq.numeric().sub(fixedA.getSInt(), unscaledB));
     });
   }
 
   @Override
   public DRes<SReal> mult(DRes<SReal> a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      SFixed floatB = (SFixed) b.out();
-      int precision = floatA.getPrecision() + floatB.getPrecision();
-      DRes<SInt> unscaled = seq.numeric().mult(floatA.getSInt(), floatB.getSInt());
-      if (precision > maxPrecision) {
-        /*
-         * We allow for 'pseudo-floating-point' numbers where the precision may increase after each
-         * multiplications and we only truncate when reaching an upper bound for the precision. This
-         * is motly effective when the precision was chosen small compared to the max bit length in
-         * the underlying field.
-         *
-         * For performance reasons, we use the Truncate algorithm instead of RightShift when
-         * truncating numbers, so every time this is done to the SInt used to represent a fixed
-         * number, eg. after multiplication, there is a propability (p ~ 0.5) that the result will
-         * be one larger than the expected value which will make the corresponding fixed point
-         * number 2^-n larger than the expected value.
-         */
-        unscaled = scale(seq, unscaled, defaultPrecision - precision);
-        precision = defaultPrecision;
-      }
-      return new SFixed(unscaled, precision);
+      SFixed fixedA = (SFixed) a.out();
+      SFixed fixedB = (SFixed) b.out();
+      DRes<SInt> result = seq.numeric().mult(fixedA.getSInt(), fixedB.getSInt());
+      DRes<SInt> truncated = scale(seq, result, -seq.getRealNumericContext().getPrecision());
+      return new SFixed(truncated);
     });
   }
 
   @Override
   public DRes<SReal> mult(BigDecimal a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatB = (SFixed) b.out();
-      int precision = defaultPrecision + floatB.getPrecision();
-      BigInteger unscaledA = unscaled(a, defaultPrecision);
-      DRes<SInt> unscaled = seq.numeric().mult(unscaledA, floatB.getSInt());
-      if (precision > maxPrecision) {
-        unscaled = scale(seq, unscaled, defaultPrecision - precision);
-        precision = defaultPrecision;
-      }
-      return new SFixed(unscaled, precision);
+      BigInteger unscaledA = unscaled(a, seq.getRealNumericContext().getPrecision());
+      SFixed fixedB = (SFixed) b.out();
+      DRes<SInt> result = seq.numeric().mult(unscaledA, fixedB.getSInt());
+      DRes<SInt> truncated = scale(seq, result, -seq.getRealNumericContext().getPrecision());
+      return new SFixed(truncated);
     });
   }
 
   @Override
   public DRes<SReal> div(DRes<SReal> a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      SFixed floatB = (SFixed) b.out();
-      DRes<SInt> intA = unscaled(seq, floatA, 2 * defaultPrecision);
-      DRes<SInt> intB = unscaled(seq, floatB, defaultPrecision);
-      DRes<SInt> scaled = seq.advancedNumeric().div(intA, intB);
-      return new SFixed(scaled, defaultPrecision);
+      SFixed fixedA = (SFixed) a.out();
+      SFixed fixedB = (SFixed) b.out();
+      DRes<SInt> scaledA = scale(seq, fixedA.getSInt(), seq.getRealNumericContext().getPrecision());
+      DRes<SInt> result = seq.advancedNumeric().div(scaledA, fixedB.getSInt());
+      return new SFixed(result);
     });
   }
 
   @Override
   public DRes<SReal> div(DRes<SReal> a, BigDecimal b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      DRes<SInt> intA = unscaled(seq, floatA, 2 * defaultPrecision);
-      BigInteger unscaledB = unscaled(b, defaultPrecision);
-      DRes<SInt> scaledResult = seq.advancedNumeric().div(intA, unscaledB);
-      return new SFixed(scaledResult, defaultPrecision);
+      SFixed fixedA = (SFixed) a.out();
+      DRes<SInt> scaledA = scale(seq, fixedA.getSInt(), seq.getRealNumericContext().getPrecision());
+      BigInteger unscaledB = unscaled(b, seq.getRealNumericContext().getPrecision());
+      DRes<SInt> result = seq.advancedNumeric().div(scaledA, unscaledB);
+      return new SFixed(result);
     });
   }
 
   @Override
   public DRes<SReal> known(BigDecimal value) {
     return builder.seq(seq -> {
-      DRes<SInt> input = seq.numeric().known(unscaled(value, defaultPrecision));
-      return new SFixed(input, defaultPrecision);
+      DRes<SInt> input = seq.numeric().known(unscaled(value, seq.getRealNumericContext().getPrecision()));
+      return new SFixed(input);
     });
   }
 
   @Override
   public DRes<SReal> fromSInt(DRes<SInt> value) {
-    return builder.seq(seq -> new SFixed(value.out(), 0));
+    return builder.seq(seq -> {
+      DRes<SInt> unscaled = scale(seq, value, seq.getRealNumericContext().getPrecision());
+      return new SFixed(unscaled);
+    });
   }
 
   @Override
   public DRes<SReal> input(BigDecimal value, int inputParty) {
     return builder.seq(seq -> {
-      DRes<SInt> input = seq.numeric().input(unscaled(value, defaultPrecision), inputParty);
-      return new SFixed(input, defaultPrecision);
+      DRes<SInt> input = seq.numeric().input(unscaled(value, seq.getRealNumericContext().getPrecision()), 
+          inputParty);
+      return new SFixed(input);
     });
   }
 
   @Override
   public DRes<BigDecimal> open(DRes<SReal> x) {
     return builder.seq(seq -> {
-      SFixed floatX = (SFixed) x.out();
-      DRes<SInt> unscaled = floatX.getSInt();
+      SFixed fixedX = (SFixed) x.out();
+      DRes<SInt> unscaled = fixedX.getSInt();
       DRes<BigInteger> unscaledOpen = seq.numeric().open(unscaled);
-      int precision = floatX.getPrecision();
-      return () -> scaled(builder.getBasicNumericContext().getFieldDefinition(), unscaledOpen.out(),
-          precision);
+      return unscaledOpen;
+    }).seq((seq, unscaledOpen) -> {
+      BigDecimal open = scaled(builder.getBasicNumericContext().getFieldDefinition(), unscaledOpen,
+          seq.getRealNumericContext().getPrecision());
+      return () -> open;
     });
   }
 
   @Override
   public DRes<BigDecimal> open(DRes<SReal> x, int outputParty) {
     return builder.seq(seq -> {
-      SFixed floatX = (SFixed) x.out();
-      DRes<SInt> unscaled = floatX.getSInt();
+      SFixed fixedX = (SFixed) x.out();
+      DRes<SInt> unscaled = fixedX.getSInt();
       DRes<BigInteger> unscaledOpen = seq.numeric().open(unscaled, outputParty);
-      int precision = floatX.getPrecision();
-      return () -> {
-        if (unscaledOpen.out() != null) {
-          return scaled(builder.getBasicNumericContext().getFieldDefinition(), unscaledOpen.out(),
-              precision);
-        } else {
-          return null;
-        }
-      };
+      return unscaledOpen;
+    }).seq((seq, unscaledOpen) -> {
+      if (outputParty == seq.getBasicNumericContext().getMyId()) {
+        BigDecimal open = scaled(builder.getBasicNumericContext().getFieldDefinition(), unscaledOpen,
+            seq.getRealNumericContext().getPrecision());
+        return () -> open;
+      } else {
+        return () -> null;
+      }
     });
   }
 
   @Override
   public DRes<SInt> leq(DRes<SReal> a, DRes<SReal> b) {
     return builder.seq(seq -> {
-      SFixed floatA = (SFixed) a.out();
-      SFixed floatB = (SFixed) b.out();
-      int scale = Math.max(floatA.getPrecision(), (floatB.getPrecision()));
-      DRes<SInt> unscaledA = unscaled(seq, floatA, scale);
-      DRes<SInt> unscaledB = unscaled(seq, floatB, scale);
-      return seq.comparison().compareLEQ(unscaledA, unscaledB);
+      SFixed fixedA = (SFixed) a.out();
+      SFixed fixedB = (SFixed) b.out();
+      return seq.comparison().compareLEQ(fixedA.getSInt(), fixedB.getSInt());
     });
   }
 }

--- a/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/SFixed.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/real/fixed/SFixed.java
@@ -2,28 +2,23 @@ package dk.alexandra.fresco.lib.real.fixed;
 
 import dk.alexandra.fresco.framework.DRes;
 import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.BasicNumericContext;
 import dk.alexandra.fresco.lib.real.SReal;
 
 /**
  * Closed datatype for representing binary fixed point numbers, e.g. represent a fraction <i>x</i>
  * as <i>m 2<sup>n</sup></i> where <i>m</i> is an {@link SInt}, <i>n &ge; 0</i> is a precision
- * (avaialble via {@link #getPrecision()}) that may vary from value to value.
+ * which is defined by the context and can be accessed through the {@link BasicNumericContext}.
  */
 public class SFixed implements SReal, DRes<SReal> {
   private final DRes<SInt> value;
-  private final int precision;
 
-  public SFixed(DRes<SInt> value, int precision) {
+  public SFixed(DRes<SInt> value) {
     this.value = value;
-    this.precision = precision;
   }
 
   public DRes<SInt> getSInt() {
     return value;
-  }
-
-  public int getPrecision() {
-    return precision;
   }
 
   @Override

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/BasicFixedPointTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/BasicFixedPointTests.java
@@ -38,21 +38,23 @@ public class BasicFixedPointTests {
 
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      List<BigDecimal> value = Stream.of(10.000001, 5.9, 11.0, 0.0001,
-          100000000.0001, 1.5 * Math.pow(2.0, -DEFAULT_PRECISION)).map(BigDecimal::valueOf)
+      List<Double> values = Stream.of(10.000001, 5.9, 11.0, 0.0001,
+          100000000.0001, 1.5 * Math.pow(2.0, -DEFAULT_PRECISION))
           .collect(Collectors.toList());
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
         public void test() {
           Application<List<BigDecimal>, ProtocolBuilderNumeric> app = producer -> {
-            List<DRes<SReal>> inputs = value.stream().map(x -> producer.realNumeric().input(x, 1))
+            List<DRes<SReal>> inputs = values.stream().map(x -> producer.realNumeric().input(x, 1))
                 .collect(Collectors.toList());
             List<DRes<BigDecimal>> opened =
                 inputs.stream().map(producer.realNumeric()::open).collect(Collectors.toList());
             return () -> opened.stream().map(DRes::out).collect(Collectors.toList());
           };
           List<BigDecimal> output = runApplication(app);
-          RealTestUtils.assertEqual(value, output, DEFAULT_PRECISION + 1);
+          RealTestUtils.assertDoublesEqual(
+              values, output,
+              DEFAULT_PRECISION + 1);
         }
       };
     }
@@ -122,8 +124,8 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
 
-      List<BigDecimal> value = Stream.of(10.000001, 5.9, 11.0, 0.0001, 100000000.0001,
-          0.5 * Math.pow(2.0, -DEFAULT_PRECISION)).map(BigDecimal::valueOf)
+      List<Double> values = Stream.of(10.000001, 5.9, 11.0, 0.0001, 100000000.0001,
+          0.5 * Math.pow(2.0, -DEFAULT_PRECISION))
           .collect(Collectors.toList());
 
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
@@ -131,13 +133,14 @@ public class BasicFixedPointTests {
         public void test() {
           Application<List<BigDecimal>, ProtocolBuilderNumeric> app = producer -> {
             List<DRes<SReal>> inputs =
-                value.stream().map(producer.realNumeric()::known).collect(Collectors.toList());
+                values.stream().map(producer.realNumeric()::known).collect(Collectors.toList());
             List<DRes<BigDecimal>> opened =
                 inputs.stream().map(producer.realNumeric()::open).collect(Collectors.toList());
             return () -> opened.stream().map(DRes::out).collect(Collectors.toList());
           };
           List<BigDecimal> output = runApplication(app);
-          RealTestUtils.assertEqual(value, output, DEFAULT_PRECISION + 1);
+          RealTestUtils.assertDoublesEqual(values, output,
+              DEFAULT_PRECISION + 1);
         }
       };
     }
@@ -149,14 +152,14 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
 
-      List<BigDecimal> openInputs = Stream
+      List<Double> openInputs = Stream
           .of(1.0001, 0.000_000_001, -1_000_000_000_000.000_100_000_000_1,
               0.5 * Math.pow(2.0, -DEFAULT_PRECISION))
-          .map(BigDecimal::valueOf).collect(Collectors.toList());
-      List<BigDecimal> openInputs2 = Stream
+          .collect(Collectors.toList());
+      List<Double> openInputs2 = Stream
           .of(-1.0001, 1_000_000_000.0, -1_000_000_000_000.000_100_000_000_1,
               0.5 * Math.pow(2.0, -DEFAULT_PRECISION))
-          .map(BigDecimal::valueOf).collect(Collectors.toList());
+          .collect(Collectors.toList());
 
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
@@ -180,9 +183,9 @@ public class BasicFixedPointTests {
           for (BigDecimal openOutput : output) {
             int idx = output.indexOf(openOutput);
 
-            BigDecimal a = openInputs.get(idx);
-            BigDecimal b = openInputs2.get(idx);
-            RealTestUtils.assertEqual(a.add(b), openOutput, DEFAULT_PRECISION);
+            Double a = openInputs.get(idx);
+            Double b = openInputs2.get(idx);
+            RealTestUtils.assertEqual(a+b, openOutput, DEFAULT_PRECISION);
           }
         }
       };
@@ -242,14 +245,14 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
 
-      List<BigDecimal> openInputs = Stream
+      List<Double> openInputs = Stream
           .of(1.000_2, 0.000_000_001, -1_000_000_000_000.000_100_000_000_1,
               2.5 * Math.pow(2.0, -DEFAULT_PRECISION))
-          .map(BigDecimal::valueOf).collect(Collectors.toList());
-      List<BigDecimal> openInputs2 = Stream
+          .collect(Collectors.toList());
+      List<Double> openInputs2 = Stream
           .of(1.000_1, 1_000_000_000.0, -1_000_000_000_000.000_100_000_000_1,
               Math.pow(2.0, -DEFAULT_PRECISION))
-          .map(BigDecimal::valueOf).collect(Collectors.toList());
+          .collect(Collectors.toList());
 
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
@@ -271,17 +274,17 @@ public class BasicFixedPointTests {
           IntStream.range(0, openInputs.size())
               .forEach(
                   idx -> {
-                    BigDecimal a = openInputs.get(idx);
-                    BigDecimal b = openInputs2.get(idx);
-                    RealTestUtils.assertEqual(a.subtract(b), output.get(idx), DEFAULT_PRECISION);
+                    double a = openInputs.get(idx);
+                    double b = openInputs2.get(idx);
+                    RealTestUtils.assertEqual(a-b, output.get(idx), DEFAULT_PRECISION);
                   });
 
           IntStream.range(openInputs.size(), output.size())
               .forEach(
                   idx -> {
-                    BigDecimal a = openInputs.get(idx - openInputs.size());
-                    BigDecimal b = openInputs2.get(idx - openInputs.size());
-                    RealTestUtils.assertEqual(b.subtract(a), output.get(idx), DEFAULT_PRECISION);
+                    double a = openInputs.get(idx - openInputs.size());
+                    double b = openInputs2.get(idx - openInputs.size());
+                    RealTestUtils.assertEqual(b-a, output.get(idx), DEFAULT_PRECISION);
                   });
         }
       };
@@ -293,18 +296,16 @@ public class BasicFixedPointTests {
 
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-      List<BigDecimal> openInputs =
+      List<Double> openInputs =
           Stream.of(1.223, 222.23, 5.59703, 0.004, 5.90, 6.0, 0.007, 0.1298, 9.99)
-              .map(BigDecimal::valueOf).collect(Collectors.toList());
-      List<BigDecimal> openInputs2 =
+              .collect(Collectors.toList());
+      List<Double> openInputs2 =
           Stream.of(1.000, 1.0000, 0.22211, 100.1, 11.0, .07, 0.005, 10.0012, 999.0101)
-              .map(BigDecimal::valueOf).collect(Collectors.toList());
+              .collect(Collectors.toList());
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
         public void test() {
           Application<List<BigDecimal>, ProtocolBuilderNumeric> app = producer -> {
-
-           
             
             List<DRes<SReal>> closed1 =
                 openInputs.stream().map(producer.realNumeric()::known).collect(Collectors.toList());
@@ -322,12 +323,12 @@ public class BasicFixedPointTests {
           List<BigDecimal> output = runApplication(app);
           for (BigDecimal openOutput : output) {
             int idx = output.indexOf(openOutput);
-            BigDecimal a = openInputs.get(idx);
-            BigDecimal b = openInputs2.get(idx);
+            double a = openInputs.get(idx);
+            double b = openInputs2.get(idx);
             // There should be no truncation after just one multiplication
             int precision = DEFAULT_PRECISION
                 - Math.max(0, Math.max(RealTestUtils.floorLog2(a), RealTestUtils.floorLog2(b)));
-            RealTestUtils.assertEqual(a.multiply(b), openOutput, precision);
+            RealTestUtils.assertEqual(a*b, openOutput, precision);
           }
         }
       };
@@ -376,8 +377,8 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
 
-      BigDecimal value = BigDecimal.valueOf(10.00100);
-      BigDecimal value2 = BigDecimal.valueOf(0.2);
+      double value = 10.00100;
+      double value2 = 0.2;
 
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
@@ -392,7 +393,7 @@ public class BasicFixedPointTests {
           BigDecimal output = runApplication(app);
           int precision = DEFAULT_PRECISION - 2
               - Math.max(0, RealTestUtils.floorLog2(value) - RealTestUtils.floorLog2(value2));
-          RealTestUtils.assertEqual(value.divide(value2), output, precision);
+          RealTestUtils.assertEqual(value / value2, output, precision);
         }
       };
     }
@@ -404,8 +405,8 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
 
-      BigDecimal value = BigDecimal.valueOf(10.00100);
-      BigDecimal value2 = BigDecimal.valueOf(-1);
+      double value = 10.00100;
+      double value2 = -1;
 
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
@@ -420,7 +421,7 @@ public class BasicFixedPointTests {
           BigDecimal output = runApplication(app);
           int precision = DEFAULT_PRECISION - 2
               - Math.max(0, RealTestUtils.floorLog2(value) - RealTestUtils.floorLog2(value2));
-          RealTestUtils.assertEqual(value.divide(value2), output, precision);
+          RealTestUtils.assertEqual(value / value2, output, precision);
         }
       };
     }

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/BasicFixedPointTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/BasicFixedPointTests.java
@@ -294,16 +294,18 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
       List<BigDecimal> openInputs =
-          Stream.of(1.223, 222.23, 5.59703, 0.004, 5.90, 6.0, 0.0007, 0.1298, 9.99)
+          Stream.of(1.223, 222.23, 5.59703, 0.004, 5.90, 6.0, 0.007, 0.1298, 9.99)
               .map(BigDecimal::valueOf).collect(Collectors.toList());
       List<BigDecimal> openInputs2 =
-          Stream.of(1.000, 1.0000, 0.22211, 100.1, 11.0, .07, 0.0005, 10.0012, 999.0101)
+          Stream.of(1.000, 1.0000, 0.22211, 100.1, 11.0, .07, 0.005, 10.0012, 999.0101)
               .map(BigDecimal::valueOf).collect(Collectors.toList());
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
         @Override
         public void test() {
           Application<List<BigDecimal>, ProtocolBuilderNumeric> app = producer -> {
 
+           
+            
             List<DRes<SReal>> closed1 =
                 openInputs.stream().map(producer.realNumeric()::known).collect(Collectors.toList());
 
@@ -324,7 +326,7 @@ public class BasicFixedPointTests {
             BigDecimal b = openInputs2.get(idx);
             // There should be no truncation after just one multiplication
             int precision = DEFAULT_PRECISION
-                - Math.max(RealTestUtils.floorLog2(a), RealTestUtils.floorLog2(b));
+                - Math.max(0, Math.max(RealTestUtils.floorLog2(a), RealTestUtils.floorLog2(b)));
             RealTestUtils.assertEqual(a.multiply(b), openOutput, precision);
           }
         }
@@ -430,11 +432,11 @@ public class BasicFixedPointTests {
     @Override
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
       List<BigDecimal> openInputs = Stream
-          .of(1.223, 222.23, 5.59703, 0.004, 5.90, 6.0, 0.0007, 0.1298,
+          .of(1.223, 222.23, 5.59703, 0.004, 5.90, 6.0, 0.007, 0.1298,
               1.5 * Math.pow(2.0, -DEFAULT_PRECISION))
           .map(BigDecimal::valueOf).collect(Collectors.toList());
       List<BigDecimal> openInputs2 = Stream
-          .of(1.000, 1.0000, 0.22211, 100.1, 11.0, .07, 0.0005, 10.0012,
+          .of(1.000, 1.0000, 0.22211, 100.1, 11.0, .07, 0.005, 10.0012,
               3.5 * Math.pow(2.0, -DEFAULT_PRECISION))
           .map(BigDecimal::valueOf).collect(Collectors.toList());
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
@@ -463,8 +465,8 @@ public class BasicFixedPointTests {
             BigDecimal a = openInputs.get(idx);
             BigDecimal b = openInputs2.get(idx);
 
-            int precision = DEFAULT_PRECISION - 1 - Math
-                .max(RealTestUtils.floorLog2(a), RealTestUtils.floorLog2(b));
+            int precision = DEFAULT_PRECISION - 1 - Math.max(0, Math
+                .max(RealTestUtils.floorLog2(a), RealTestUtils.floorLog2(b)));
             RealTestUtils.assertEqual(a.multiply(b), openOutput, precision);
           }
         }

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/MathTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/MathTests.java
@@ -59,7 +59,7 @@ public class MathTests {
               producer -> producer.seq(seq -> {
                 List<DRes<SReal>> result = new ArrayList<>();
                 for (int i = 0; i < 10; i++) {
-                  result.add(seq.realAdvanced().random(DEFAULT_PRECISION));
+                  result.add(seq.realAdvanced().random());
                 }
 
                 List<DRes<BigDecimal>> opened =

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/RealTestUtils.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/RealTestUtils.java
@@ -3,6 +3,7 @@ package dk.alexandra.fresco.lib.real;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 
 class RealTestUtils {
@@ -18,6 +19,10 @@ class RealTestUtils {
     Assert.assertTrue(a + " == " + b + " +/- 2^"
         + ceilLog2(d) + " but expected precision " + precision, d.compareTo(bound) <= 0);
   }
+  
+  static void assertEqual(double a, BigDecimal b, int precision) {
+    assertEqual(BigDecimal.valueOf(a), b, precision);
+  }
 
   static void assertEqual(List<BigDecimal> a, List<BigDecimal> b, int precision) {
     Assert.assertTrue("Lists must be of same size", a.size() == b.size());
@@ -25,12 +30,26 @@ class RealTestUtils {
       assertEqual(a.get(i), b.get(i), precision);
     }
   }
+  
+  static void assertDoublesEqual(List<Double> a, List<BigDecimal> b, int precision) {
+    assertEqual(a.stream().map(BigDecimal::valueOf).collect(Collectors.toList()), b, precision);
+  }
+
 
   static int floorLog2(BigDecimal value) {
-    return (int) Math.floor(Math.log(value.doubleValue()) / Math.log(2.0));
+    return floorLog2(value.doubleValue());
   }
 
-  static int ceilLog2(BigDecimal value) {
-    return (int) Math.ceil(Math.log(value.doubleValue()) / Math.log(2.0));
+  static int floorLog2(double value) {
+    return (int) Math.floor(Math.log(value) / Math.log(2.0));
   }
+  
+  static int ceilLog2(BigDecimal value) {
+    return ceilLog2(value.doubleValue());
+  }
+  
+  static int ceilLog2(double value) {
+    return (int) Math.ceil(Math.log(value) / Math.log(2.0));
+  }
+
 }

--- a/core/src/test/java/dk/alexandra/fresco/lib/real/fixed/TestFixedNumeric.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/real/fixed/TestFixedNumeric.java
@@ -18,27 +18,11 @@ public class TestFixedNumeric {
     BuilderFactoryNumeric bfn = new DummyArithmeticBuilderFactory(
         new BasicNumericContext(16, 1, 1, fieldDefinition),
         new RealNumericContext(0));
-    new FixedNumeric(bfn.createSequential(), 4);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testFixedNumericPrecisionTooLarge() {
-    BuilderFactoryNumeric bfn = new DummyArithmeticBuilderFactory(
-        new BasicNumericContext(16, 1, 1, fieldDefinition),
-        new RealNumericContext(0));
-    new FixedNumeric(bfn.createSequential(), 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testFixedNumericPrecisionTooLow() {
-    BuilderFactoryNumeric bfn = new DummyArithmeticBuilderFactory(
-        new BasicNumericContext(16, 1, 1, fieldDefinition),
-        new RealNumericContext(0));
-    new FixedNumeric(bfn.createSequential(), -1);
+    new FixedNumeric(bfn.createSequential());
   }
 
   @Test(expected = NullPointerException.class)
   public void testFixedNumericNullBuilder() {
-    new FixedNumeric(null, -1);
+    new FixedNumeric(null);
   }
 }

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -786,13 +786,6 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
   }
 
   @Test
-  public void test_Real_Sqrt_Uneven_Precision() {
-    runTest(new MathTests.TestSqrt<>(),
-        new TestParameters()
-            .fixedPointPrecesion(BasicFixedPointTests.DEFAULT_PRECISION + 1));
-  }
-
-  @Test
   public void test_trunctation() {
     runTest(new TruncationTests.TestTruncation<>(), new TestParameters().numParties(2));
   }


### PR DESCRIPTION
Remove the "pseudo floating point" implementation. It complicated the implementation and testing and has limited use for smaller moduli.