### PR TITLE
added possibility to pre-produce triples, random elements, etc. for SPDZ/MASCOT

### DIFF
--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzDataSupplier.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzDataSupplier.java
@@ -17,6 +17,13 @@ public interface SpdzDataSupplier {
   SpdzTriple getNextTriple();
 
   /**
+   * Produces a number of triples
+   *
+   * @param numTriples the number of triples to be produced
+   */
+  void produceTriples(int numTriples);
+
+  /**
    * Supplies the next exponentiation pipe. <p>An exponentiation pipe is a list of numbers in the
    * following format: r^{-1}, r, r^{2}, r^{3}, ..., r^{l}, where r is a random element, l is the
    * length of exponentiation pipe, and all exponentiations are mod the prime we are working with.
@@ -35,11 +42,26 @@ public interface SpdzDataSupplier {
   SpdzInputMask getNextInputMask(int towardPlayerId);
 
   /**
+   * Produces a number of inputmasks
+   *
+   * @param towardPlayerId the id of the input player
+   * @param numMasks the number of masks to be produced
+   */
+  void produceInputMasks(int towardsPlayerId, int numMasks);
+
+  /**
    * Supplies the next bit (i.e. a SpdzSInt representing a value in {0, 1}).
    *
    * @return the next new bit
    */
   SpdzSInt getNextBit();
+
+  /**
+   * Produces a number of random bits
+   *
+   * @param numBits the number of bits to be produced
+   */
+  void produceBits(int numBits);
 
   /**
    * The field definition used for this instance of SPDZ.
@@ -62,4 +84,11 @@ public interface SpdzDataSupplier {
    * @return A SpdzSInt representing a random secret shared field element.
    */
   SpdzSInt getNextRandomFieldElement();
+
+  /**
+   * Produces a number of random elements
+   *
+   * @param numElements the number of random elements to be produced
+   */
+  void produceRandomFieldElements(int numElements);
 }

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzDummyDataSupplier.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzDummyDataSupplier.java
@@ -44,6 +44,11 @@ public class SpdzDummyDataSupplier implements SpdzDataSupplier {
   }
 
   @Override
+  public void produceTriples(int numTriples) {
+    // Dummy does nothing here
+  }
+
+  @Override
   public SpdzSInt[] getNextExpPipe() {
     List<Pair<BigInteger, BigInteger>> rawExpPipe = supplier.getExpPipe(expPipeLength);
     return rawExpPipe.stream()
@@ -62,8 +67,18 @@ public class SpdzDummyDataSupplier implements SpdzDataSupplier {
   }
 
   @Override
+  public void produceInputMasks(int towardsPlayerId, int numMasks) {
+    // Dummy does nothing here
+  }
+
+  @Override
   public SpdzSInt getNextBit() {
     return toSpdzSInt(supplier.getRandomBitShare());
+  }
+
+  @Override
+  public void produceBits(int numBits) {
+    // Dummy does nothing here
   }
 
   @Override
@@ -79,6 +94,11 @@ public class SpdzDummyDataSupplier implements SpdzDataSupplier {
   @Override
   public SpdzSInt getNextRandomFieldElement() {
     return toSpdzSInt(supplier.getRandomElementShare());
+  }
+
+  @Override
+  public void produceRandomFieldElements(int numElements) {
+    // Dummy does nothing here
   }
 
   private SpdzSInt toSpdzSInt(Pair<BigInteger, BigInteger> raw) {

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzMascotDataSupplier.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzMascotDataSupplier.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 public class SpdzMascotDataSupplier implements SpdzDataSupplier {
 
   private static final Logger logger = LoggerFactory.getLogger(SpdzMascotDataSupplier.class);
+  private static final int PRODUCE_LIMIT = 1024;
   private final int myId;
   private final int instanceId;
   private final int numberOfPlayers;
@@ -129,6 +130,20 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
   }
 
   @Override
+  public void produceTriples(int numTriples) {
+    ensureInitialized();
+    logger.trace("Getting another " + numTriples + " triples");
+    int toProduce = numTriples;
+    while (toProduce > 0) {
+      // Limit the number of elements produced at once
+      int produce = (toProduce > PRODUCE_LIMIT) ? PRODUCE_LIMIT : toProduce;
+      triples.addAll(mascot.getTriples(produce));
+      toProduce = toProduce - produce;
+    }
+    logger.trace("Got another " + numTriples + " triples");
+  }
+
+  @Override
   public SpdzSInt getNextRandomFieldElement() {
     ensureInitialized();
     if (randomElements.isEmpty()) {
@@ -137,6 +152,20 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
       logger.trace("Got another random element batch");
     }
     return MascotFormatConverter.toSpdzSInt(randomElements.pop());
+  }
+
+  @Override
+  public void produceRandomFieldElements(int numElements) {
+    ensureInitialized();
+    logger.trace("Getting another " + numElements + " random elements");
+    int toProduce = numElements;
+    while (toProduce > 0) {
+      // Limit the number of elements produced at once
+      int produce = (toProduce > PRODUCE_LIMIT) ? PRODUCE_LIMIT : toProduce;
+      randomElements.addAll(mascot.getRandomElements(produce));
+      toProduce = toProduce - produce;
+    }
+    logger.trace("Got another " + numElements + " random elements");
   }
 
   @Override
@@ -160,6 +189,21 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
   }
 
   @Override
+  public void produceInputMasks(int towardsPlayerId, int numMasks) {
+    ensureInitialized();
+    ArrayDeque<InputMask> inputMasks = masks.get(towardsPlayerId);
+    logger.trace("Getting another " + numMasks + " masks");
+    int toProduce = numMasks;
+    while (toProduce > 0) {
+      // Limit the number of elements produced at once
+      int produce = (toProduce > PRODUCE_LIMIT) ? PRODUCE_LIMIT : toProduce;
+      inputMasks.addAll(mascot.getInputMasks(towardsPlayerId, produce));
+      toProduce = toProduce - produce;
+    }
+    logger.trace("Got another " + numMasks + " masks");
+  }
+
+  @Override
   public SpdzSInt getNextBit() {
     ensureInitialized();
     if (randomBits.isEmpty()) {
@@ -168,6 +212,20 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
       logger.trace("Got another bit batch");
     }
     return MascotFormatConverter.toSpdzSInt(randomBits.pop());
+  }
+
+  @Override
+  public void produceBits(int numBits) {
+    ensureInitialized();
+    logger.trace("Getting another " + numBits + " random bits");
+    int toProduce = numBits;
+    while (toProduce > 0) {
+      // Limit the number of elements produced at once
+      int produce = (toProduce > PRODUCE_LIMIT) ? PRODUCE_LIMIT : toProduce;
+      randomBits.addAll(mascot.getRandomBits(produce));
+      toProduce = toProduce - produce;
+    }
+    logger.trace("Got another " + numBits + " random bits");
   }
 
   @Override

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzStorageDataSupplier.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzStorageDataSupplier.java
@@ -82,6 +82,11 @@ public class SpdzStorageDataSupplier implements SpdzDataSupplier {
   }
 
   @Override
+  public void produceTriples(int numTriples) {
+    // StorageDataSupplier does not produce!
+  }
+
+  @Override
   public SpdzSInt[] getNextExpPipe() {
     SpdzSInt[] expPipe;
     try {
@@ -116,6 +121,11 @@ public class SpdzStorageDataSupplier implements SpdzDataSupplier {
   }
 
   @Override
+  public void produceInputMasks(int towardsPlayerId, int numMasks) {
+    // StorageDataSupplier does not produce!
+  }
+
+  @Override
   public SpdzSInt getNextBit() {
     SpdzSInt bit;
     try {
@@ -129,6 +139,11 @@ public class SpdzStorageDataSupplier implements SpdzDataSupplier {
     }
     bitCounter++;
     return bit;
+  }
+
+  @Override
+  public void produceBits(int numBits) {
+    // StorageDataSupplier does not produce!
   }
 
   @Override
@@ -164,5 +179,10 @@ public class SpdzStorageDataSupplier implements SpdzDataSupplier {
   public SpdzSInt getNextRandomFieldElement() {
     // TODO: We should probably have a random element storage stream
     return this.getNextTriple().getA();
+  }
+
+  @Override
+  public void produceRandomFieldElements(int numElements) {
+    // StorageDataSupplier does not produce!
   }
 }


### PR DESCRIPTION
Pull request for the [Issue 346](https://github.com/aicis/fresco/issues/346).

I added the produce_limit to the Mascot data supplier, because bigger number of elements (several hundred thousands) would have crashed the code.