### PR TITLE
Cleans up after spdz filebased storage test

### DIFF
--- a/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/storage/TestSpdzStorage.java
+++ b/suite/spdz/src/test/java/dk/alexandra/fresco/suite/spdz/storage/TestSpdzStorage.java
@@ -2,18 +2,32 @@ package dk.alexandra.fresco.suite.spdz.storage;
 
 import dk.alexandra.fresco.framework.sce.resources.storage.FilebasedStreamedStorageImpl;
 import dk.alexandra.fresco.framework.sce.resources.storage.InMemoryStorage;
+import java.io.File;
 import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 
 public class TestSpdzStorage {
 
+  /**
+   * Removes all files in this directory with given file names.
+   */
+  private void removeFiles(List<String> fileNames) {
+    for (String fileName : fileNames) {
+      new File(fileName).deleteOnExit();
+    }
+  }
+
   @Test
   public void testDataSupplierModFoundTwice() {
     FilebasedStreamedStorageImpl storage = new FilebasedStreamedStorageImpl(new InMemoryStorage());
-    storage.putNext("valid" + SpdzStorageDataSupplier.MODULUS_KEY, BigInteger.ONE);
+    String fileName = "valid" + SpdzStorageDataSupplier.MODULUS_KEY;
+    storage.putNext(fileName, BigInteger.ONE);
     SpdzStorageDataSupplier supplier = new SpdzStorageDataSupplier(storage, "valid", 2);
     supplier.getFieldDefinition();
     supplier.getFieldDefinition();
+    removeFiles(Collections.singletonList(fileName));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR cleans up files created during file-based storage tests.

RIP `valid_ModP` ⚰️
