### PR TITLE
New division protocol with more predicitable output

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/framework/builder/numeric/AdvancedNumeric.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/builder/numeric/AdvancedNumeric.java
@@ -4,6 +4,7 @@ import dk.alexandra.fresco.framework.DRes;
 import dk.alexandra.fresco.framework.builder.ComputationDirectory;
 import dk.alexandra.fresco.framework.util.Pair;
 import dk.alexandra.fresco.framework.value.SInt;
+import dk.alexandra.fresco.lib.field.integer.BasicNumericContext;
 import java.math.BigInteger;
 import java.util.List;
 
@@ -29,8 +30,9 @@ public interface AdvancedNumeric extends ComputationDirectory {
   DRes<SInt> product(List<DRes<SInt>> elements);
 
   /**
-   * This protocol calculates an approximation of <code>floor(dividend / divisor)</code>, which will
-   * be either correct or slightly smaller than the correct result.
+   * This protocol calculates <code>floor(dividend / divisor)</code>. The result is guaranteed to be
+   * correct if the bit length of the dividend is smaller than {@link BasicNumericContext#getMaxBitLength()}
+   * / 2.
    *
    * @param dividend The dividend.
    * @param divisor The divisor.

--- a/core/src/main/java/dk/alexandra/fresco/lib/math/integer/division/KnownDivisor.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/math/integer/division/KnownDivisor.java
@@ -7,14 +7,14 @@ import dk.alexandra.fresco.framework.builder.numeric.ProtocolBuilderNumeric;
 import dk.alexandra.fresco.framework.builder.numeric.field.FieldDefinition;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericContext;
+import dk.alexandra.fresco.lib.real.fixed.utils.Truncate;
 import java.math.BigInteger;
 
 /**
- * This protocol is an implementation Euclidean division (finding quotient and remainder) on
- * integers with a secret shared divedend and a known divisor. The dividend must have bitlength
- * smaller than <i>(maxBitLenght - divisorBitLength) / 3</i> where the maxBitLength is avabilable
- * via {@link ProtocolBuilderNumeric#getBasicNumericContext().getMaxBitLength()} in order for the
- * division protocol to produce a precise result.
+ * This protocol is an implementation of Euclidean division on integers with a secret shared
+ * dividend and a known divisor. The dividend must have bit length smaller than half the
+ * maxBitLength (available via {@link ProtocolBuilderNumeric#getBasicNumericContext().getMaxBitLength()})
+ * in order for the division protocol to produce a precise result.
  */
 public class KnownDivisor implements Computation<SInt, ProtocolBuilderNumeric> {
 
@@ -25,7 +25,7 @@ public class KnownDivisor implements Computation<SInt, ProtocolBuilderNumeric> {
    * Constructs a division computation where the divisor is publicly known.
    *
    * @param dividend the dividend
-   * @param divisor the publicly known divisor
+   * @param divisor  the publicly known divisor
    */
   public KnownDivisor(DRes<SInt> dividend, BigInteger divisor) {
     this.dividend = dividend;
@@ -34,61 +34,66 @@ public class KnownDivisor implements Computation<SInt, ProtocolBuilderNumeric> {
 
   @Override
   public DRes<SInt> buildComputation(ProtocolBuilderNumeric builder) {
-    BasicNumericContext basicNumericContext = builder.getBasicNumericContext();
-    /*
-     * We use the fact that if 2^{N+l} \leq m * d \leq 2^{N+l} + 2^l, then floor(x/d) = floor(x * m
-     * >> N+l) for all x of length <= N (see Thm 4.2 of
-     * "Division by Invariant Integers using Multiplication" by Granlund and Montgomery).
-     *
-     * TODO: Note that if the dividend is nonnegative, the sign considerations can be omitted,
-     * giving a significant speed-up.
-     */
+    return builder.seq(seq -> {
 
-    Numeric numeric = builder.numeric();
-    /*
-     * Numbers larger than half the field size is considered to be negative.
-     *
-     * TODO: This should be handled differently because it will not necessarily work with another
-     * arithmetic protocol suite.
-     */
-    FieldDefinition fieldDefinition = basicNumericContext.getFieldDefinition();
-    BigInteger signedDivisor = fieldDefinition.convertToSigned(divisor);
-    int divisorSign = signedDivisor.signum();
-    BigInteger divisorAbs = signedDivisor.abs();
-    int maxDivisorBitLength = basicNumericContext.getMaxBitLength() - 3;
-    if (divisorAbs.bitLength() > maxDivisorBitLength) {
-      throw new IllegalArgumentException("Divisor is too big. Bit length is "
-          + divisorAbs.bitLength() + " but should only be at most " + maxDivisorBitLength);
-    }
-    /*
-     * The quotient will have bit length < 2 * maxBitLength, and this has to be shifted maxBitLength
-     * + divisorBitLength. So in total we need 3 * maxBitLength + divisorBitLength to be
-     * representable.
-     */
-    int maxBitLength = (basicNumericContext.getMaxBitLength() - divisorAbs.bitLength()) / 3;
-    int shifts = maxBitLength + divisorAbs.bitLength();
-    /*
-     * Compute the sign of the dividend
-     */
-    DRes<SInt> dividendSign = builder.comparison().sign(dividend);
-    DRes<SInt> dividendAbs = numeric.mult(dividend, dividendSign);
+      BasicNumericContext basicNumericContext = seq.getBasicNumericContext();
+      Numeric numeric = seq.numeric();
 
-    /*
-     * We need m * d \geq 2^{N+l}, so we add one to the result of the division to ensure that this
-     * is indeed the case.
-     */
-    BigInteger m = BigInteger.ONE.shiftLeft(shifts).divide(divisorAbs).add(BigInteger.ONE);
-    DRes<SInt> quotientAbs = numeric.mult(m, dividendAbs);
-    /*
-     * Now quotientAbs is the result shifted SHIFTS bits to the left, so we shift it back to get the
-     * result in absolute value, q.
-     */
-    DRes<SInt> q = builder.advancedNumeric().rightShift(quotientAbs, shifts);
-    /*
-     * Adjust the sign of the result.
-     */
-    BigInteger openDivisorSign = BigInteger.valueOf(divisorSign);
-    DRes<SInt> sign = numeric.mult(openDivisorSign, dividendSign);
-    return numeric.mult(q, sign);
+      /*
+       * We use the fact that if 2^{N+l} \leq m * d \leq 2^{N+l} + 2^l, then floor(x/d) = floor(x * m
+       * >> N+l) for all x of length <= N (see Thm 4.2 of
+       * "Division by Invariant Integers using Multiplication" by Granlund and Montgomery).
+       */
+
+      /*
+       * Numbers larger than half the field size is considered to be negative.
+       */
+      FieldDefinition fieldDefinition = basicNumericContext.getFieldDefinition();
+      BigInteger signedDivisor = fieldDefinition.convertToSigned(divisor);
+      int divisorSign = signedDivisor.signum();
+      BigInteger divisorAbs = signedDivisor.abs();
+
+      int n = basicNumericContext.getMaxBitLength() / 2;
+
+      /*
+       * Compute the sign of the dividend
+       */
+      DRes<SInt> dividendSign = seq.comparison().sign(dividend);
+      DRes<SInt> dividendAbs = numeric.mult(dividend, dividendSign);
+
+      /*
+       * We need m * d \geq 2^{N+l}, so we add one to the result of the division to ensure that this
+       * is indeed the case.
+       */
+      BigInteger m = BigInteger.ONE.shiftLeft(2 * n - 1).divide(divisorAbs)
+          .add(BigInteger.ONE);
+
+      /*
+       * Represent m in base 2^n.
+       */
+      BigInteger m0 = m.mod(BigInteger.ONE.shiftLeft(n));
+      BigInteger m1 = m.mod(BigInteger.ONE.shiftLeft(2 * n)).shiftRight(n);
+
+      /*
+       * Compute the product m * dividend in this base. Note that we may have overflow.
+       */
+      DRes<SInt> mx0 = seq.numeric().mult(m0, dividendAbs);
+      DRes<SInt> mx1 = seq.numeric().mult(m1, dividendAbs);
+
+      /*
+       * Now, the quotient is the result shifted SHIFTS bits to the left, so we shift it back to get the
+       * result in absolute value. Only the most significant bits of mx0 may influence mx1 so a truncate
+       * is sufficient here.
+       */
+      DRes<SInt> q = seq.advancedNumeric().rightShift(seq.numeric().add(mx1,
+          new Truncate(mx0, n).buildComputation(seq)), n - 1);
+
+      /*
+       * Adjust the sign of the result.
+       */
+      BigInteger openDivisorSign = BigInteger.valueOf(divisorSign);
+      DRes<SInt> sign = numeric.mult(openDivisorSign, dividendSign);
+      return numeric.mult(q, sign);
+    });
   }
 }

--- a/core/src/test/java/dk/alexandra/fresco/lib/math/integer/division/DivisionTests.java
+++ b/core/src/test/java/dk/alexandra/fresco/lib/math/integer/division/DivisionTests.java
@@ -56,8 +56,8 @@ public class DivisionTests {
     public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
 
       return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-        private final BigInteger dividend = new BigInteger("123978634193227335452345761");
-        private final BigInteger divisor = new BigInteger("6543212341214412");
+        private final BigInteger dividend = new BigInteger("123978634193227335452");
+        private final BigInteger divisor = new BigInteger("6543212341");
 
         @Override
         public void test() throws Exception {
@@ -68,34 +68,6 @@ public class DivisionTests {
           BigInteger remainder = result.getSecond();
           Assert.assertThat(quotient, Is.is(dividend.divide(divisor)));
           Assert.assertThat(remainder, Is.is(dividend.mod(divisor)));
-        }
-
-      };
-    }
-  }
-
-  /**
-   * Tests division computation with known divisor (as implemented in {@link KnownDivisor})
-   * with a divisor that is too large for the computation to work. Note: This test should be
-   * expected to throw an {@link IllegalArgumentException}
-   */
-  public static class TestKnowndivisorTooLargeDivisor<ResourcePoolT extends ResourcePool>
-      extends TestThreadFactory<ResourcePoolT, ProtocolBuilderNumeric> {
-
-    @Override
-    public TestThread<ResourcePoolT, ProtocolBuilderNumeric> next() {
-
-      return new TestThread<ResourcePoolT, ProtocolBuilderNumeric>() {
-
-        @Override
-        public void test() throws Exception {
-          Application<SInt, ProtocolBuilderNumeric> app = (builder) -> {
-            int maxLength = builder.getBasicNumericContext().getMaxBitLength();
-            BigInteger divisor = BigInteger.valueOf(2).pow(maxLength);
-            DRes<SInt> dividend = builder.numeric().known(BigInteger.TEN);
-            return builder.seq(new KnownDivisor(dividend, divisor));
-          };
-          runApplication(app);
         }
 
       };

--- a/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
+++ b/core/src/test/java/dk/alexandra/fresco/suite/dummy/arithmetic/TestDummyArithmeticProtocolSuite.java
@@ -351,12 +351,6 @@ public class TestDummyArithmeticProtocolSuite extends AbstractDummyArithmeticTes
         new TestParameters());
   }
 
-  @Test(expected = RuntimeException.class)
-  public void test_euclidian_division_too_large_divisor() {
-    runTest(new DivisionTests.TestKnowndivisorTooLargeDivisor<>(),
-        new TestParameters());
-  }
-
   @Test
   public void test_ss_division() {
     runTest(new DivisionTests.TestDivision<>(), new TestParameters().performanceLogging(true));


### PR DESCRIPTION
The old division protocol had a rather annoying requirement on the input sizes of both the dividend and divisor. This protocol simplifies this to allow the divisor to be of any size and the dividend to be up to half the max bit length.