### PR TITLE
Create matrix with entry builder

### DIFF
--- a/lib/common/src/main/java/dk/alexandra/fresco/lib/common/collections/Matrix.java
+++ b/lib/common/src/main/java/dk/alexandra/fresco/lib/common/collections/Matrix.java
@@ -2,8 +2,10 @@ package dk.alexandra.fresco.lib.common.collections;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Matrix<T> {
 
@@ -25,6 +27,18 @@ public class Matrix<T> {
     for (int i = 0; i < height; i++) {
       this.matrix.add(rowBuilder.apply(i));
     }
+  }
+
+  /**
+   * Create a new function with the given entry building function.
+   *
+   * @param height height of the matrix
+   * @param width width of the matrix
+   * @param builder function for building entries given the indices of row and column resp.
+   */
+  public Matrix(int height, int width, BiFunction<Integer, Integer, T> builder) {
+    this(height, width, i -> IntStream.range(0, width).mapToObj(j -> builder.apply(i, j)).collect(
+        Collectors.toCollection(ArrayList::new)));
   }
 
   /**

--- a/lib/common/src/test/java/dk/alexandra/fresco/lib/common/collections/MatrixTest.java
+++ b/lib/common/src/test/java/dk/alexandra/fresco/lib/common/collections/MatrixTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,13 +14,13 @@ public class MatrixTest {
 
   @Test
   public void testToString() {
-    IntFunction<ArrayList<Integer>> mockFunction = mock(IntFunction.class);
-    when(mockFunction.apply(any(int.class))).thenReturn(new ArrayList<>());
+    BiFunction<Integer, Integer, Integer> mockFunction = mock(BiFunction.class);
+    when(mockFunction.apply(any(Integer.class), any(Integer.class))).thenReturn(0);
     Matrix matrix = new Matrix(1, 2, mockFunction);
 
     String stringOut = matrix.toString();
     Assert.assertTrue(stringOut.contains("width=2,"));
     Assert.assertTrue(stringOut.contains("height=1,"));
-    Assert.assertTrue(stringOut.contains("matrix=[[]]"));
+    Assert.assertTrue(stringOut.contains("matrix=[[0, 0]]"));
   }
 }


### PR DESCRIPTION
It is more convenient to define a matrix by what the (i,j)'th entry looks like than by building rows, so we add a new constructor to the Matrix class which can do this.