### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,7 +38,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <excludedGroups>dk.alexandra.fresco.IntegrationTest</excludedGroups>
         </configuration>

--- a/suite/spdz/pom.xml
+++ b/suite/spdz/pom.xml
@@ -159,7 +159,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <excludedGroups>dk.alexandra.fresco.IntegrationTest</excludedGroups>
         </configuration>

--- a/suite/tinytables/pom.xml
+++ b/suite/tinytables/pom.xml
@@ -87,7 +87,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <excludedGroups>dk.alexandra.fresco.IntegrationTest</excludedGroups>
         </configuration>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
