### PR TITLE
Added significant amount of validation to components

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/framework/Party.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/Party.java
@@ -1,5 +1,8 @@
 package dk.alexandra.fresco.framework;
 
+import dk.alexandra.fresco.framework.util.ValidationUtils;
+import java.util.Objects;
+
 /**
  * FRESCO's view of a MPC party.
  */
@@ -17,8 +20,10 @@ public class Party {
    * @param port the tcp port to connect on
    */
   public Party(int id, String host, int port) {
+    ValidationUtils.assertValidId(id);
+
     this.id = id;
-    this.host = host;
+    this.host = Objects.requireNonNull(host);
     this.port = port;
   }
 

--- a/core/src/main/java/dk/alexandra/fresco/framework/configuration/NetworkConfigurationImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/configuration/NetworkConfigurationImpl.java
@@ -2,6 +2,7 @@ package dk.alexandra.fresco.framework.configuration;
 
 import dk.alexandra.fresco.framework.Party;
 import dk.alexandra.fresco.framework.util.Pair;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -14,14 +15,22 @@ public class NetworkConfigurationImpl implements NetworkConfiguration {
   private final Map<Integer, Party> parties;
 
   public NetworkConfigurationImpl(int myId, Map<Integer, Party> parties) {
+    // Validation
     Objects.requireNonNull(parties);
     checkAddressesUnique(parties);
+    ValidationUtils.assertValidId(myId);
+    if (parties.get(myId) == null) {
+      throw new RuntimeException(String.format("myId %d must be in the parties map: %s", myId, parties));
+    }
+
+    // Set fields
     this.myId = myId;
     this.parties = parties;
   }
 
   @Override
   public Party getParty(int id) {
+    ValidationUtils.assertValidId(id);
     return parties.get(id);
   }
 

--- a/core/src/main/java/dk/alexandra/fresco/framework/sce/SecureComputationEngineImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/sce/SecureComputationEngineImpl.java
@@ -10,6 +10,7 @@ import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.suite.ProtocolSuite;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -39,13 +40,13 @@ public class SecureComputationEngineImpl
   /**
    * Creates a new {@link SecureComputationEngineImpl}.
    *
-   * @param protocolSuite the {@link ProtocolSuite} to use to evaluate the secure computation
-   * @param evaluator the {@link ProtocolEvaluator} to run secure evaluation.
+   * @param protocolSuite {@link ProtocolSuite} to use to evaluate the secure computation. Not nullable.
+   * @param evaluator {@link ProtocolEvaluator} to run secure evaluation. Not nullable.
    */
   public SecureComputationEngineImpl(ProtocolSuite<ResourcePoolT, BuilderT> protocolSuite,
       ProtocolEvaluator<ResourcePoolT> evaluator) {
-    this.protocolSuite = protocolSuite;
-    this.evaluator = evaluator;
+    this.protocolSuite = Objects.requireNonNull(protocolSuite);
+    this.evaluator = Objects.requireNonNull(evaluator);
     this.setup = false;
   }
 

--- a/core/src/main/java/dk/alexandra/fresco/framework/sce/evaluator/BatchedProtocolEvaluator.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/sce/evaluator/BatchedProtocolEvaluator.java
@@ -5,6 +5,7 @@ import dk.alexandra.fresco.framework.ProtocolProducer;
 import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.suite.ProtocolSuite;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,9 +35,9 @@ public class BatchedProtocolEvaluator<ResourcePoolT extends ResourcePool>
   public BatchedProtocolEvaluator(
       BatchEvaluationStrategy<ResourcePoolT> batchEvaluator,
       ProtocolSuite<ResourcePoolT, ?> protocolSuite, int maxBatchSize) {
-    this.batchEvaluator = batchEvaluator;
+    this.batchEvaluator = Objects.requireNonNull(batchEvaluator);
     this.maxBatchSize = maxBatchSize;
-    this.protocolSuite = protocolSuite;
+    this.protocolSuite = Objects.requireNonNull(protocolSuite);
   }
 
   @Override

--- a/core/src/main/java/dk/alexandra/fresco/framework/sce/resources/ResourcePoolImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/sce/resources/ResourcePoolImpl.java
@@ -1,5 +1,7 @@
 package dk.alexandra.fresco.framework.sce.resources;
 
+import dk.alexandra.fresco.framework.util.ValidationUtils;
+
 /**
  * Container for resources needed by runtimes (protocol suites).
  */
@@ -12,10 +14,13 @@ public class ResourcePoolImpl implements ResourcePool {
    * Creates an instance of the default implementation of a resource pool. This contains the basic
    * resources needed within FRESCO.
    *
-   * @param myId The ID of the MPC party.
+   * @param myId The ID of the MPC party. Must be a valid id, but may lie
+   * outside of {@code noOfPlayers} as some subclasses create sub-networks, with fewer noOfPlayers.
    * @param noOfPlayers The amount of parties within the MPC computation.
    */
   public ResourcePoolImpl(int myId, int noOfPlayers) {
+    ValidationUtils.assertValidId(myId);
+    ValidationUtils.assertValidId(noOfPlayers);
     this.myId = myId;
     this.noOfPlayers = noOfPlayers;
   }

--- a/core/src/main/java/dk/alexandra/fresco/framework/util/ArithmeticDummyDataSupplier.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/util/ArithmeticDummyDataSupplier.java
@@ -9,8 +9,9 @@ import java.util.stream.IntStream;
 
 /**
  * Supplies generic pre-processed material common across arithmetic SPDZ-like suites, including
- * random elements, bits, and multiplication triples. <p>Uses {@link Random} to deterministically
- * generate all material. NOT secure.</p>
+ * random elements, bits, and multiplication triples.
+ *
+ * <p>Uses {@link Random} to deterministically generate all material. This is not secure, and should not be used in production code!
  */
 public class ArithmeticDummyDataSupplier {
 
@@ -21,8 +22,9 @@ public class ArithmeticDummyDataSupplier {
   private final Random random;
   private final SecretSharer<BigInteger> sharer;
   private final ModularReductionAlgorithm reducer;
-  
+
   public ArithmeticDummyDataSupplier(int myId, int noOfParties, BigInteger modulus) {
+    ValidationUtils.assertValidId(myId, noOfParties);
     this.myId = myId;
     this.noOfParties = noOfParties;
     this.modulus = modulus;

--- a/core/src/main/java/dk/alexandra/fresco/framework/util/DrngImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/util/DrngImpl.java
@@ -1,6 +1,7 @@
 package dk.alexandra.fresco.framework.util;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * A simple implementation based on a deterministic bit generator.
@@ -14,10 +15,10 @@ public class DrngImpl implements Drng {
 
   /**
    * Creates a number generator from a bit generator.
-   * @param drbg a deterministic random bit generator
+   * @param drbg a deterministic random bit generator. Not nullable.
    */
   public DrngImpl(Drbg drbg) {
-    this.drbg = drbg;
+    this.drbg = Objects.requireNonNull(drbg);
   }
 
   @Override

--- a/core/src/main/java/dk/alexandra/fresco/framework/util/ValidationUtils.java
+++ b/core/src/main/java/dk/alexandra/fresco/framework/util/ValidationUtils.java
@@ -1,0 +1,34 @@
+package dk.alexandra.fresco.framework.util;
+
+/** Contains methods for validating ids. */
+public final class ValidationUtils {
+
+  private ValidationUtils() {}
+
+  /**
+   * Validates that the given party id is within the valid range of ids, without a known max id.
+   *
+   * @param partyId Id to validate
+   * @exception IllegalArgumentException if id is not valid
+   */
+  public static void assertValidId(int partyId) {
+    if (partyId < 1) {
+      throw new IllegalArgumentException(String.format("Party id %d must be one-indexed", partyId));
+    }
+  }
+
+  /**
+   * Validates that the given party id is within the valid range of ids, with a known max id.
+   *
+   * @param partyId Id to validate
+   * @param numParties Max id
+   * @exception IllegalArgumentException if id is not valid
+   */
+  public static void assertValidId(int partyId, int numParties) {
+    assertValidId(partyId);
+    if (numParties < partyId) {
+      throw new IllegalArgumentException(
+          String.format("Party id %d must be in range [1,%d]", partyId, numParties));
+    }
+  }
+}

--- a/core/src/main/java/dk/alexandra/fresco/lib/field/integer/BasicNumericContext.java
+++ b/core/src/main/java/dk/alexandra/fresco/lib/field/integer/BasicNumericContext.java
@@ -1,7 +1,9 @@
 package dk.alexandra.fresco.lib.field.integer;
 
 import dk.alexandra.fresco.framework.builder.numeric.field.FieldDefinition;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * Holds the most crucial properties about the finite field we are working within.
@@ -24,12 +26,13 @@ public class BasicNumericContext {
    *     have.
    * @param myId my party id
    * @param noOfParties number of parties in computation
-   * @param fieldDefinition the field definition used in the application
+   * @param fieldDefinition the field definition used in the application. Nullable.
    * @param defaultFixedPointPrecision the fixed point precision when using the fixed point library
    * @param statisticalSecurityParam the statistical security parameter
    */
   public BasicNumericContext(int maxBitLength, int myId, int noOfParties,
       FieldDefinition fieldDefinition, int defaultFixedPointPrecision, int statisticalSecurityParam) {
+    ValidationUtils.assertValidId(myId, noOfParties);
     this.maxBitLength = maxBitLength;
     this.myId = myId;
     this.noOfParties = noOfParties;

--- a/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticResourcePoolImpl.java
+++ b/core/src/main/java/dk/alexandra/fresco/suite/dummy/arithmetic/DummyArithmeticResourcePoolImpl.java
@@ -3,6 +3,7 @@ package dk.alexandra.fresco.suite.dummy.arithmetic;
 import dk.alexandra.fresco.framework.builder.numeric.field.FieldDefinition;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePool;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 
 /**
  * Implements the resource pool needed for the Dummy Arithmetic suite.
@@ -22,6 +23,7 @@ public class DummyArithmeticResourcePoolImpl extends ResourcePoolImpl
   public DummyArithmeticResourcePoolImpl(int myId, int noOfPlayers,
       FieldDefinition fieldDefinition) {
     super(myId, noOfPlayers);
+    ValidationUtils.assertValidId(myId, noOfPlayers);
     this.fieldDefinition = fieldDefinition;
   }
 

--- a/core/src/test/java/dk/alexandra/fresco/framework/TestThreadRunner.java
+++ b/core/src/test/java/dk/alexandra/fresco/framework/TestThreadRunner.java
@@ -193,15 +193,15 @@ public class TestThreadRunner {
               iterator.remove();
             }
           } catch (InterruptedException e) {
-            throw new TestFrameworkException("Test was interrupted");
+            throw new TestFrameworkException("Test was interrupted", e);
           }
           if (t.setupException != null) {
-            throw new TestFrameworkException(t + " threw exception in setup (see stderr)");
+            throw new TestFrameworkException(t + " threw exception in setup", t.setupException);
           } else if (t.testException != null) {
-            throw new TestFrameworkException(t + " threw exception in test (see stderr)",
+            throw new TestFrameworkException(t + " threw exception in test",
                 t.testException);
           } else if (t.teardownException != null) {
-            throw new TestFrameworkException(t + " threw exception in teardown (see stderr)");
+            throw new TestFrameworkException(t + " threw exception in teardown", t.setupException);
           }
         }
       }

--- a/core/src/test/java/dk/alexandra/fresco/framework/sce/TestSecureComputationEngineImpl.java
+++ b/core/src/test/java/dk/alexandra/fresco/framework/sce/TestSecureComputationEngineImpl.java
@@ -57,7 +57,7 @@ public class TestSecureComputationEngineImpl {
           return builder.numeric().open(builder.numeric().add(a, b));
         };
     DummyArithmeticResourcePool rp =
-        new DummyArithmeticResourcePoolImpl(0, 1, fieldDefinition);
+        new DummyArithmeticResourcePoolImpl(1, 1, fieldDefinition);
 
     BigInteger b = sce.runApplication(app, rp, null);
     assertThat(b, is(BigInteger.valueOf(20)));
@@ -72,7 +72,7 @@ public class TestSecureComputationEngineImpl {
           return builder.numeric().open(builder.numeric().add(a, b));
         };
     DummyArithmeticResourcePool rp =
-        new DummyArithmeticResourcePoolImpl(0, 1, fieldDefinition);
+        new DummyArithmeticResourcePoolImpl(1, 1, fieldDefinition);
 
     BigInteger b = sce.runApplication(app, rp, null);
     assertThat(b, is(BigInteger.valueOf(20)));
@@ -85,7 +85,7 @@ public class TestSecureComputationEngineImpl {
           throw new RuntimeException();
         };
     DummyArithmeticResourcePool rp =
-        new DummyArithmeticResourcePoolImpl(0, 1, fieldDefinition);
+        new DummyArithmeticResourcePoolImpl(1, 1, fieldDefinition);
     sce.runApplication(app, rp, null);
     fail("Should not be reachable");
   }
@@ -99,7 +99,7 @@ public class TestSecureComputationEngineImpl {
           }
         };
     DummyArithmeticResourcePool rp =
-        new DummyArithmeticResourcePoolImpl(0, 1, fieldDefinition);
+        new DummyArithmeticResourcePoolImpl(1, 1, fieldDefinition);
     sce.runApplication(app, rp, null, Duration.ofNanos(1));
     fail("Should not be reachable");
   }

--- a/core/src/test/java/dk/alexandra/fresco/framework/sce/resources/TestResourcePoolImpl.java
+++ b/core/src/test/java/dk/alexandra/fresco/framework/sce/resources/TestResourcePoolImpl.java
@@ -9,8 +9,8 @@ public class TestResourcePoolImpl {
 
   @Test
   public void testResourcePoolImpl() {
-    ResourcePoolImpl rp = new ResourcePoolImpl(0, 1);
-    assertThat(rp.getMyId(), is(0));
+    ResourcePoolImpl rp = new ResourcePoolImpl(1, 1);
+    assertThat(rp.getMyId(), is(1));
     assertThat(rp.getNoOfParties(), is(1));
   }
 

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/SpdzResourcePoolImpl.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/SpdzResourcePoolImpl.java
@@ -6,12 +6,14 @@ import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.ExceptionConverter;
 import dk.alexandra.fresco.framework.util.OpenedValueStore;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzSInt;
 import dk.alexandra.fresco.suite.spdz.storage.SpdzDataSupplier;
 import java.security.MessageDigest;
+import java.util.Objects;
 import java.util.function.Function;
 
-public class SpdzResourcePoolImpl extends ResourcePoolImpl implements SpdzResourcePool {
+public final class SpdzResourcePoolImpl extends ResourcePoolImpl implements SpdzResourcePool {
 
   private static final int DRBG_SEED_LENGTH = 256;
 
@@ -26,21 +28,22 @@ public class SpdzResourcePoolImpl extends ResourcePoolImpl implements SpdzResour
    *
    * @param myId The id of the party
    * @param noOfPlayers The amount of parties
-   * @param openedValueStore Store for maintaining opened values for later mac check
-   * @param dataSupplier Pre-processing material supplier
-   * @param drbgSupplier Function instantiating DRBG with given seed
+   * @param openedValueStore Store for maintaining opened values for later mac check. Not nullable.
+   * @param dataSupplier Pre-processing material supplier. Not nullable.
+   * @param drbgSupplier Function instantiating DRBG with given seed. Not nullable.
    * @param drbgSeedBitLength Required bit length of seed used for DRBGs
    */
   public SpdzResourcePoolImpl(int myId, int noOfPlayers,
       OpenedValueStore<SpdzSInt, FieldElement> openedValueStore, SpdzDataSupplier dataSupplier,
       Function<byte[], Drbg> drbgSupplier, int drbgSeedBitLength) {
     super(myId, noOfPlayers);
-    this.dataSupplier = dataSupplier;
-    this.openedValueStore = openedValueStore;
+    ValidationUtils.assertValidId(myId, noOfPlayers);
+    this.dataSupplier = Objects.requireNonNull(dataSupplier);
+    this.openedValueStore = Objects.requireNonNull(openedValueStore);
     this.messageDigest = ExceptionConverter.safe(
         () -> MessageDigest.getInstance("SHA-256"),
         "Configuration error, SHA-256 is needed for Spdz");
-    this.drbgSupplier = drbgSupplier;
+    this.drbgSupplier = Objects.requireNonNull(drbgSupplier);
     this.drbgSeedBitLength = drbgSeedBitLength;
   }
 

--- a/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzMascotDataSupplier.java
+++ b/suite/spdz/src/main/java/dk/alexandra/fresco/suite/spdz/storage/SpdzMascotDataSupplier.java
@@ -5,6 +5,7 @@ import dk.alexandra.fresco.framework.builder.numeric.field.FieldElement;
 import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.StrictBitVector;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzInputMask;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzSInt;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzTriple;
@@ -22,6 +23,7 @@ import java.security.SecureRandom;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -61,7 +63,7 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
    * @param tripleNetwork network supplier for network to be used by Mascot instance
    * @param fieldDefinition field definition
    * @param modBitLength bit length of modulus
-   * @param preprocessedValues callback to generate exponentiation pipes
+   * @param preprocessedValues callback to generate exponentiation pipes. Nullable.
    * @param prgSeedLength bit length of prg
    * @param batchSize batch size in which Mascot will generate pre-processed material
    * @param ssk mac key share
@@ -72,12 +74,13 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
       Supplier<Network> tripleNetwork, FieldDefinition fieldDefinition, int modBitLength,
       Function<Integer, SpdzSInt[]> preprocessedValues, int prgSeedLength, int batchSize,
       FieldElement ssk, Map<Integer, RotList> seedOts, Drbg drbg) {
+    ValidationUtils.assertValidId(myId, numberOfPlayers);
     this.myId = myId;
     this.numberOfPlayers = numberOfPlayers;
     this.instanceId = instanceId;
-    this.tripleNetwork = tripleNetwork;
-    this.fieldDefinition = fieldDefinition;
-    this.preprocessedValues = preprocessedValues;
+    this.tripleNetwork = Objects.requireNonNull(tripleNetwork);
+    this.fieldDefinition = Objects.requireNonNull(fieldDefinition);
+    this.preprocessedValues = preprocessedValues; // Allow null.
     this.triples = new ArrayDeque<>();
     this.masks = new HashMap<>();
     for (int partyId = 1; partyId <= numberOfPlayers; partyId++) {
@@ -88,9 +91,9 @@ public class SpdzMascotDataSupplier implements SpdzDataSupplier {
     this.prgSeedLength = prgSeedLength;
     this.modBitLength = modBitLength;
     this.batchSize = batchSize;
-    this.ssk = ssk;
-    this.seedOts = seedOts;
-    this.drbg = drbg;
+    this.ssk = Objects.requireNonNull(ssk);
+    this.seedOts = Objects.requireNonNull(seedOts);
+    this.drbg = Objects.requireNonNull(drbg);
   }
 
   /**

--- a/suite/spdz2k/src/main/java/dk/alexandra/fresco/suite/spdz2k/resource/Spdz2kResourcePoolImpl.java
+++ b/suite/spdz2k/src/main/java/dk/alexandra/fresco/suite/spdz2k/resource/Spdz2kResourcePoolImpl.java
@@ -18,6 +18,7 @@ import dk.alexandra.fresco.framework.util.AesCtrDrbg;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.ExceptionConverter;
 import dk.alexandra.fresco.framework.util.OpenedValueStore;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.lib.field.integer.BasicNumericContext;
 import dk.alexandra.fresco.suite.spdz2k.Spdz2kBuilder;
 import dk.alexandra.fresco.suite.spdz2k.datatypes.CompUInt;
@@ -54,6 +55,7 @@ public class Spdz2kResourcePoolImpl<PlainT extends CompUInt<?, ?, PlainT>>
       OpenedValueStore<Spdz2kSInt<PlainT>, PlainT> storage,
       Spdz2kDataSupplier<PlainT> supplier, CompUIntFactory<PlainT> factory) {
     super(myId, noOfPlayers);
+    ValidationUtils.assertValidId(myId, noOfPlayers);
     Objects.requireNonNull(storage);
     Objects.requireNonNull(supplier);
     Objects.requireNonNull(factory);

--- a/tools/bitTriples/src/main/java/dk/alexandra/fresco/tools/bitTriples/BitTripleResourcePoolImpl.java
+++ b/tools/bitTriples/src/main/java/dk/alexandra/fresco/tools/bitTriples/BitTripleResourcePoolImpl.java
@@ -5,6 +5,7 @@ import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.ExceptionConverter;
 import dk.alexandra.fresco.framework.util.StrictBitVector;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.tools.bitTriples.prg.BytePrg;
 import dk.alexandra.fresco.tools.bitTriples.prg.BytePrgImpl;
 import dk.alexandra.fresco.tools.cointossing.CoinTossing;
@@ -42,6 +43,7 @@ public class BitTripleResourcePoolImpl extends ResourcePoolImpl implements BitTr
       Drbg drbg,
       BitTripleSecurityParameters bitTripleSecurityParameters) {
     super(myId, noOfParties);
+    ValidationUtils.assertValidId(myId, noOfParties);
     this.drbg = drbg;
     this.instanceId = instanceId;
     this.bitTripleSecurityParameters = bitTripleSecurityParameters;

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/MascotResourcePoolImpl.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/MascotResourcePoolImpl.java
@@ -6,6 +6,7 @@ import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.ExceptionConverter;
 import dk.alexandra.fresco.framework.util.StrictBitVector;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.tools.cointossing.CoinTossing;
 import dk.alexandra.fresco.tools.mascot.prg.FieldElementPrg;
 import dk.alexandra.fresco.tools.mascot.prg.FieldElementPrgImpl;
@@ -14,6 +15,7 @@ import dk.alexandra.fresco.tools.ot.otextension.*;
 
 import java.security.MessageDigest;
 import java.util.Map;
+import java.util.Objects;
 
 public class MascotResourcePoolImpl extends ResourcePoolImpl implements MascotResourcePool {
 
@@ -43,11 +45,12 @@ public class MascotResourcePoolImpl extends ResourcePoolImpl implements MascotRe
       Map<Integer, RotList> seedOts, MascotSecurityParameters mascotSecurityParameters,
       FieldDefinition fieldDefinition) {
     super(myId, noOfParties);
-    this.drbg = drbg;
+    ValidationUtils.assertValidId(myId, noOfParties);
+    this.drbg = Objects.requireNonNull(drbg);
     this.instanceId = instanceId;
-    this.seedOts = seedOts;
-    this.fieldDefinition = fieldDefinition;
-    this.mascotSecurityParameters = mascotSecurityParameters;
+    this.seedOts = Objects.requireNonNull(seedOts);
+    this.fieldDefinition = Objects.requireNonNull(fieldDefinition);
+    this.mascotSecurityParameters = Objects.requireNonNull(mascotSecurityParameters);
     this.localSampler = new FieldElementPrgImpl(
         new StrictBitVector(mascotSecurityParameters.getPrgSeedLength(), drbg),
         this.fieldDefinition);

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/commit/CommitmentBasedInput.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/commit/CommitmentBasedInput.java
@@ -8,6 +8,7 @@ import dk.alexandra.fresco.tools.mascot.broadcast.BroadcastValidation;
 import dk.alexandra.fresco.tools.mascot.broadcast.BroadcastingNetworkProxy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -30,9 +31,9 @@ public abstract class CommitmentBasedInput<T> {
    */
   public CommitmentBasedInput(MascotResourcePool resourcePool, Network network,
       ByteSerializer<T> serializer) {
-    this.resourcePool = resourcePool;
-    this.network = network;
-    this.serializer = serializer;
+    this.resourcePool = Objects.requireNonNull(resourcePool);
+    this.network = Objects.requireNonNull(network);
+    this.serializer = Objects.requireNonNull(serializer);
     // for more than two parties, we need to use broadcast
     if (resourcePool.getNoOfParties() > 2) {
       this.broadcaster =

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/cope/CopeInputter.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/cope/CopeInputter.java
@@ -5,12 +5,14 @@ import dk.alexandra.fresco.framework.builder.numeric.field.FieldElement;
 import dk.alexandra.fresco.framework.network.Network;
 import dk.alexandra.fresco.framework.util.Pair;
 import dk.alexandra.fresco.framework.util.StrictBitVector;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.tools.mascot.MascotResourcePool;
 import dk.alexandra.fresco.tools.mascot.mult.MultiplyRightHelper;
 import dk.alexandra.fresco.tools.mascot.prg.FieldElementPrg;
 import dk.alexandra.fresco.tools.mascot.prg.FieldElementPrgImpl;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -41,9 +43,10 @@ public class CopeInputter {
    * seeds used in the <i>Extend</i> sub-protocol.</p>
    */
   public CopeInputter(MascotResourcePool resourcePool, Network network, int otherId) {
+    ValidationUtils.assertValidId(otherId);
     this.otherId = otherId;
-    this.resourcePool = resourcePool;
-    this.network = network;
+    this.resourcePool = Objects.requireNonNull(resourcePool);
+    this.network = Objects.requireNonNull(network);
     this.leftPrgs = new ArrayList<>();
     this.rightPrgs = new ArrayList<>();
     this.helper = new MultiplyRightHelper(resourcePool, network, otherId);

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/elgen/AdditiveSecretSharer.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/elgen/AdditiveSecretSharer.java
@@ -5,6 +5,7 @@ import dk.alexandra.fresco.framework.builder.numeric.field.FieldElement;
 import dk.alexandra.fresco.framework.util.SecretSharer;
 import dk.alexandra.fresco.tools.mascot.prg.FieldElementPrg;
 import java.util.List;
+import java.util.Objects;
 
 public class AdditiveSecretSharer implements SecretSharer<FieldElement> {
 
@@ -16,7 +17,7 @@ public class AdditiveSecretSharer implements SecretSharer<FieldElement> {
    * @param sampler source of randomness
    */
   AdditiveSecretSharer(FieldElementPrg sampler) {
-    this.sampler = sampler;
+    this.sampler = Objects.requireNonNull(sampler);
   }
 
   @Override

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/elgen/ElementGeneration.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/elgen/ElementGeneration.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,13 +45,13 @@ public class ElementGeneration {
    */
   public ElementGeneration(MascotResourcePool resourcePool, Network network,
       FieldElement macKeyShare, FieldElementPrg jointSampler) {
-    this.resourcePool = resourcePool;
-    this.network = network;
+    this.resourcePool = Objects.requireNonNull(resourcePool);
+    this.network = Objects.requireNonNull(network);
     this.fieldElementUtils = new FieldElementUtils(resourcePool.getFieldDefinition());
     this.macChecker = new MacCheck(resourcePool, network);
-    this.macKeyShare = macKeyShare;
-    this.localSampler = resourcePool.getLocalSampler();
-    this.jointSampler = jointSampler;
+    this.macKeyShare = Objects.requireNonNull(macKeyShare);
+    this.localSampler = Objects.requireNonNull(resourcePool.getLocalSampler());
+    this.jointSampler = Objects.requireNonNull(jointSampler);
     this.sharer = new AdditiveSecretSharer(localSampler);
     this.copeSigners = new HashMap<>();
     this.copeInputters = new HashMap<>();

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/prg/FieldElementPrgImpl.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/prg/FieldElementPrgImpl.java
@@ -7,6 +7,7 @@ import dk.alexandra.fresco.framework.util.AesCtrDrbgFactory;
 import dk.alexandra.fresco.framework.util.Drng;
 import dk.alexandra.fresco.framework.util.DrngImpl;
 import dk.alexandra.fresco.framework.util.StrictBitVector;
+import java.util.Objects;
 
 public class FieldElementPrgImpl implements FieldElementPrg {
 
@@ -19,7 +20,7 @@ public class FieldElementPrgImpl implements FieldElementPrg {
    * @param seed seed to the underlying DRNG.
    */
   public FieldElementPrgImpl(StrictBitVector seed, FieldDefinition definition) {
-    this.definition = definition;
+    this.definition = Objects.requireNonNull(definition);
     byte[] bytes = seed.toByteArray();
     if (bytes.length != AesCtrDrbg.SEED_LENGTH) {
       this.drng = new DrngImpl(AesCtrDrbgFactory.fromDerivedSeed(bytes));

--- a/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/triple/TripleGeneration.java
+++ b/tools/mascot/src/main/java/dk/alexandra/fresco/tools/mascot/triple/TripleGeneration.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -39,13 +40,13 @@ public class TripleGeneration {
    */
   public TripleGeneration(MascotResourcePool resourcePool, Network network,
       ElementGeneration elementGeneration, FieldElementPrg jointSampler) {
-    this.resourcePool = resourcePool;
+    this.resourcePool = Objects.requireNonNull(resourcePool);
     this.fieldElementUtils = new FieldElementUtils(resourcePool.getFieldDefinition());
     this.leftMultipliers = new HashMap<>();
     this.rightMultipliers = new HashMap<>();
     initializeMultipliers(resourcePool, network);
-    this.elementGeneration = elementGeneration;
-    this.jointSampler = jointSampler;
+    this.elementGeneration = Objects.requireNonNull(elementGeneration);
+    this.jointSampler = Objects.requireNonNull(jointSampler);
   }
 
   private void initializeMultipliers(MascotResourcePool resourcePool, Network network) {

--- a/tools/mascot/src/test/java/dk/alexandra/fresco/tools/mascot/TestMascotResourcePoolImpl.java
+++ b/tools/mascot/src/test/java/dk/alexandra/fresco/tools/mascot/TestMascotResourcePoolImpl.java
@@ -3,6 +3,7 @@ package dk.alexandra.fresco.tools.mascot;
 import dk.alexandra.fresco.framework.builder.numeric.field.BigIntegerFieldDefinition;
 import dk.alexandra.fresco.framework.util.AesCtrDrbg;
 import dk.alexandra.fresco.framework.util.ModulusFinder;
+import java.util.Map;
 import org.junit.Test;
 
 public class TestMascotResourcePoolImpl {
@@ -11,7 +12,7 @@ public class TestMascotResourcePoolImpl {
   @Test(expected = IllegalArgumentException.class)
   public void testCreateRotForSelf() {
     MascotResourcePool resourcePool = new MascotResourcePoolImpl(1, 1, 1,
-        new AesCtrDrbg(new byte[32]), null, new MascotSecurityParameters(),
+        new AesCtrDrbg(new byte[32]), Map.of(), new MascotSecurityParameters(),
         new BigIntegerFieldDefinition(ModulusFinder.findSuitableModulus(128)));
     resourcePool.createRot(1, null);
   }

--- a/tools/mascot/src/test/java/dk/alexandra/fresco/tools/mascot/triple/TestTripleGeneration.java
+++ b/tools/mascot/src/test/java/dk/alexandra/fresco/tools/mascot/triple/TestTripleGeneration.java
@@ -154,13 +154,14 @@ public class TestTripleGeneration extends NetworkedTest {
 
   private void testMultiplePartiesTriple(List<FieldElement> macKeyShares, int numTriples) {
     // set up runtime environment and get contexts
-    initContexts(macKeyShares.size());
+    final int noOfParties = macKeyShares.size();
+    initContexts(noOfParties);
 
     // define per party task with params
     List<Callable<List<MultiplicationTriple>>> tasks = new ArrayList<>();
-    for (int pid = 1; pid <= macKeyShares.size(); pid++) {
-      MascotTestContext partyCtx = contexts.get(pid);
-      FieldElement macKeyShare = macKeyShares.get(pid - 1);
+    for (int partyId = 1; partyId <= noOfParties; partyId++) {
+      MascotTestContext partyCtx = contexts.get(partyId);
+      FieldElement macKeyShare = macKeyShares.get(partyId - 1);
       Callable<List<MultiplicationTriple>> partyTask =
           () -> runSinglePartyTriple(partyCtx, macKeyShare, numTriples);
       tasks.add(partyTask);

--- a/tools/ot/src/main/java/dk/alexandra/fresco/tools/ot/otextension/BristolOtExtensionResourcePool.java
+++ b/tools/ot/src/main/java/dk/alexandra/fresco/tools/ot/otextension/BristolOtExtensionResourcePool.java
@@ -3,6 +3,7 @@ package dk.alexandra.fresco.tools.ot.otextension;
 import dk.alexandra.fresco.framework.sce.resources.ResourcePoolImpl;
 import dk.alexandra.fresco.framework.util.Drbg;
 import dk.alexandra.fresco.framework.util.ExceptionConverter;
+import dk.alexandra.fresco.framework.util.ValidationUtils;
 import dk.alexandra.fresco.tools.cointossing.CoinTossing;
 import java.security.MessageDigest;
 
@@ -35,6 +36,7 @@ public class BristolOtExtensionResourcePool extends ResourcePoolImpl implements
       int computationalSecurityParam, int lambdaSecurityParam, int instanceId,
       Drbg drbg, CoinTossing ct, RotList seedOts) {
     super(myId, 2);
+    ValidationUtils.assertValidId(otherId);
     if (computationalSecurityParam < 1 || lambdaSecurityParam < 1
         || lambdaSecurityParam % 8 != 0 || computationalSecurityParam
         % 8 != 0) {
@@ -55,12 +57,6 @@ public class BristolOtExtensionResourcePool extends ResourcePoolImpl implements
         "Configuration error, SHA-256 is needed for OT extension");
     this.ct = ct;
     this.seedOts = seedOts;
-  }
-
-  @Override
-  public int getNoOfParties() {
-    // By definition OT is a two-party protocol
-    return 2;
   }
 
   @Override

--- a/tools/ot/src/main/java/dk/alexandra/fresco/tools/ot/otextension/RotFactory.java
+++ b/tools/ot/src/main/java/dk/alexandra/fresco/tools/ot/otextension/RotFactory.java
@@ -1,11 +1,12 @@
 package dk.alexandra.fresco.tools.ot.otextension;
 
 import dk.alexandra.fresco.framework.network.Network;
+import java.util.Objects;
 
 /**
  * Abstract factory for a protocol instance of random OT extension.
  */
-public class RotFactory {
+public final class RotFactory {
 
   private final OtExtensionResourcePool resources;
   private final Network network;
@@ -17,8 +18,8 @@ public class RotFactory {
    * @param network   The network instance
    */
   public RotFactory(OtExtensionResourcePool resources, Network network) {
-    this.resources = resources;
-    this.network = network;
+    this.resources = Objects.requireNonNull(resources);
+    this.network = Objects.requireNonNull(network);
   }
 
   public OtExtensionResourcePool getResources() {


### PR DESCRIPTION
Implement #417, by preventing lazy errors, where the primary issue is an incorrect configuration, but where the runtime error only occurs once the computation is running, resulting in difficult to diagnose errors.

The two ways this was accomplished by:

- Add partyId validation whereever possible.
- Add `Objects.requireNonNull` checks in component constructors.

Additionally:

- Added improved dianostics for failing futures in MASCOT `TestRuntime`.